### PR TITLE
Fix bug in sector calculation

### DIFF
--- a/Pokitto/POKITTO_HW/iap.cpp
+++ b/Pokitto/POKITTO_HW/iap.cpp
@@ -49,9 +49,11 @@ int CopyPageToFlash (uint32_t address, uint8_t* data) {
 
     /* Check is it the first page in the sector */
     if (sector < 24) {
-        if (address == sector * 0x1000) firstpage = true;
+        /* 4KB addresses cover 0x000 - 0xFFF range */
+        firstpage = ((address & 0x0FFF) == 0);
     } else {
-        if (address == (sector - 24) * 0x8000 + 0x18000) firstpage = true;
+        /* 32KB addresses cover 0x0000 - 0x7FFF and 0x8000 - 0xFFFF range */
+        firstpage = ((address & 0x7FFF) == 0);
     }
 
 	/* Prepare the sector for writing */

--- a/Pokitto/POKITTO_HW/iap.cpp
+++ b/Pokitto/POKITTO_HW/iap.cpp
@@ -48,10 +48,10 @@ int CopyPageToFlash (uint32_t address, uint8_t* data) {
     else sector = 24;
 
     /* Check is it the first page in the sector */
-    if (sector<24) {
+    if (sector < 24) {
         if (address == sector * 0x1000) firstpage = true;
     } else {
-        if (address == (sector-24)*0x4000 + 0x18000) firstpage = true;
+        if (address == (sector - 24) * 0x8000 + 0x18000) firstpage = true;
     }
 
 	/* Prepare the sector for writing */


### PR DESCRIPTION
Sectors above `0x18000` are 32KB (`0x8000` bytes).
The code was erroneously using 16KB (`0x4000`) by mistake.