### PR TITLE
Fixed hanging USB serial problem when cable is disconnected.

### DIFF
--- a/Pokitto/POKITTO_LIBS/MicroPython/UsbSerialPrint.cpp
+++ b/Pokitto/POKITTO_LIBS/MicroPython/UsbSerialPrint.cpp
@@ -39,9 +39,18 @@
 
 #ifndef POK_SIM
 #include "USBSerial.h"
+
 #ifdef USE_SEGGER_SERIAL_PRINT
+// Note that to be able to use TeraTerm with Segger J-Link, Tera Term must be configured
+// not to send the whole line only after <return>. Each char should be send immediately:
+// TERATERM.INI: EnableLineMode=off
+// That is needed e.g. Python interactive prompt via the terminal. Normally, this mode is set
+// automatically but somehow TeraTerm does not recognize J-Link connection correctly.
+// TeraTerm must be connected to the telnet port "localhost:19021".
+
 #include "SEGGER_RTT.h"
 #endif
+
 #endif
 #include "PythonBindings.h"
 

--- a/Pokitto/POKITTO_LIBS/USBDevice/USBDevice/USBHAL_LPC11U.cpp
+++ b/Pokitto/POKITTO_LIBS/USBDevice/USBDevice/USBHAL_LPC11U.cpp
@@ -665,6 +665,17 @@ void USBHAL::usbisr(void) {
     if (LPC_USB->INTSTAT & DEV_INT) {
         LPC_USB->INTSTAT = DEV_INT;
 
+        if (LPC_USB->DEVCMDSTAT & DCON_C) {
+            // Bus reset
+            LPC_USB->DEVCMDSTAT = devCmdStat | DCON_C;
+
+            // Disable endpoints > 0
+            disableEndpoints();
+
+            // Bus reset event
+            busReset();
+        }
+
         if (LPC_USB->DEVCMDSTAT & DSUS_C) {
             // Suspend status changed
             LPC_USB->DEVCMDSTAT = devCmdStat | DSUS_C;


### PR DESCRIPTION
- In USBHAL::usbisr(void) checks if connection has been changed (i.e. the cable is connected or disconnected). As we cannot know which one the case is, we always do reset.
- This works around the case that the cable is disconnected but we still try to write to the port and hang there.