### PR TITLE
Remove unused variable

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoCore.h
+++ b/Pokitto/POKITTO_CORE/PokittoCore.h
@@ -179,8 +179,6 @@ public:
   static void setVolLimit();
 
 // BUTTON INPUT HANDLING
-private:
-  static uint8_t heldStates[];
 public:
   static void initButtons();
   static void pollButtons();


### PR DESCRIPTION
When examining the button code I noticed there were two `heldStates` arrays and one was unused.
Most likely this is either a remnant of old code or an oversight.

This PR removes the unused array.