### PR TITLE
Remove the dependency on the C drive

### DIFF
--- a/Pokitto/POKITTO_SIM/PokittoSimulator.h
+++ b/Pokitto/POKITTO_SIM/PokittoSimulator.h
@@ -54,10 +54,10 @@
 #define SIM_SDL_AUDIO   1       // nonzero = initialize SDL audio
 #define SIM_FULLSCREEN  0       // nonzero = run in fullscreen. WARNING ! Debug may hang !
 #define SIM_SHOWDEVICE  0       // nonzero = show Pokitto device in simulation
-#define SCREENCAPTURE   1      // nonzero = the nth frame will be written to disk
+#define SCREENCAPTURE   0      // nonzero = the nth frame will be written to disk
 #define SOUNDCAPTURE    0       // nonzero = continuous capture of sound stream to disk
-#define USE_JOYSTICK    1       // check for presence & use a game controller (analog stick is not supported yet)
-#define MAKE_GIF        1       // nonzero = make a gif using ImageMagick Convert
+#define USE_JOYSTICK    0       // check for presence & use a game controller (analog stick is not supported yet)
+#define MAKE_GIF        0       // nonzero = make a gif using ImageMagick Convert
 
 /** INTERNAL SETTINGS, DO NOT CHANGE UNLESS YOU UNDERSTAND WHAT YOU'RE DOING **/
 //#if SCREENCAPTURE > 1

--- a/Pokitto/POKITTO_SIM/PokittoSimulator.h
+++ b/Pokitto/POKITTO_SIM/PokittoSimulator.h
@@ -54,10 +54,10 @@
 #define SIM_SDL_AUDIO   1       // nonzero = initialize SDL audio
 #define SIM_FULLSCREEN  0       // nonzero = run in fullscreen. WARNING ! Debug may hang !
 #define SIM_SHOWDEVICE  0       // nonzero = show Pokitto device in simulation
-#define SCREENCAPTURE   0      // nonzero = the nth frame will be written to disk
+#define SCREENCAPTURE   1      // nonzero = the nth frame will be written to disk
 #define SOUNDCAPTURE    0       // nonzero = continuous capture of sound stream to disk
-#define USE_JOYSTICK    0       // check for presence & use a game controller (analog stick is not supported yet)
-#define MAKE_GIF        0       // nonzero = make a gif using ImageMagick Convert
+#define USE_JOYSTICK    1       // check for presence & use a game controller (analog stick is not supported yet)
+#define MAKE_GIF        1       // nonzero = make a gif using ImageMagick Convert
 
 /** INTERNAL SETTINGS, DO NOT CHANGE UNLESS YOU UNDERSTAND WHAT YOU'RE DOING **/
 //#if SCREENCAPTURE > 1
@@ -155,6 +155,7 @@ private:
   static uint16_t sc_count; // counter to decide at which intervals a screen capture is taken
   static uint16_t framenumber; // framenumber is the number of the frame
   static uint16_t audframenumber; // framenumber is the number of the frame
+  static const char * screencapPath;
 
   /** button input related */
   static uint8_t buttons_state;


### PR DESCRIPTION
Not everyone has a C drive or wants their C drive to be written to.
This change causes the files to be written relative to the executable.

Note that I've only tested the `ffmpeg` functions, I haven't tested the `convert` functions.