### PR TITLE
Revert "Automatically calculate checksum using linker script"

### DIFF
--- a/Pokitto/mbed-pokitto/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/LPC11U68.ld
+++ b/Pokitto/mbed-pokitto/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/LPC11U68.ld
@@ -232,13 +232,4 @@ SECTIONS
     
     PROVIDE(_pvHeapStart = .);
     PROVIDE(_vStackTop = __top_Ram0_32 - 0);
-
-    PROVIDE(__valid_user_code_checksum = 0 - (
-    				       _vStackTop +
-				       (ResetISR + 1) +                        // The reset handler
-				       (NMI_Handler + 1) +                     // The NMI handler
-				       (HardFault_Handler + 1)               // The hard fault handler
-				       
-    ) );
-
 }

--- a/Pokitto/mbed-pokitto/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/startup_LPC11U68.cpp
+++ b/Pokitto/mbed-pokitto/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/startup_LPC11U68.cpp
@@ -15,7 +15,6 @@ extern unsigned int __bss_section_table_end;
 extern void __libc_init_array(void);
 extern int main(void);
 extern void _vStackTop(void);
-extern void __valid_user_code_checksum(void);
 extern void (* const g_pfnVectors[])(void);
 
      void ResetISR(void);
@@ -68,7 +67,7 @@ void (* const g_pfnVectors[])(void) = {
     0,                               // Reserved
     0,                               // Reserved
     0,                               // Reserved
-    __valid_user_code_checksum,                               // Reserved
+    0,                               // Reserved
     0,                               // Reserved
     0,                               // Reserved
     0,                               // Reserved


### PR DESCRIPTION
Reverts pokitto/PokittoLib#41

c:/program files (x86)/embitz/1.11/share/em_armgcc/bin/../lib/gcc/arm-none-eabi/5.4.1/../../../../arm-none-eabi/bin/ld.exe:Pokitto/mbed-pokitto/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/LPC11U68.ld:238: syntax error