### PR TITLE
Fix warnings in PokittoCookie.cpp

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoCookie.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoCookie.cpp
@@ -136,6 +136,7 @@ bool Cookie::loadCookie() {
     _block=0;
     _block=findMyNextBlock();
     for (int i=0; i<_datasize; i++) *p++ = readQueue();
+    return true;
 }
 
 void Cookie::deleteCookie() {

--- a/Pokitto/POKITTO_CORE/PokittoCookie.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoCookie.cpp
@@ -360,6 +360,7 @@ void Cookie::writeQueue(char data) {
 int Cookie::findMyNextBlock() {
     if (!_status) return SBINVALIDBLOCK;
     for (int i=_block; i<SBMAXBLOCKS;i++) if (isMyBlock(i)) return i;
+    return SBINVALIDBLOCK;
 }
 
 

--- a/Pokitto/POKITTO_CORE/PokittoCookie.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoCookie.cpp
@@ -126,6 +126,7 @@ bool Cookie::saveCookie() {
     #if POK_ENABLE_SOUND
     Pokitto::soundInit(true); //re-init sound
     #endif
+    return true;
 }
 
 bool Cookie::loadCookie() {


### PR DESCRIPTION
Fixes three warnings of the type:
`warning: control reaches end of non-void function [-Wreturn-type]`

These warnings are potentially serious because they result in _undefined behaviour_.
I.e. the return values are indeterminate.