### PR TITLE
Mode 13 fixes

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
@@ -1606,17 +1606,15 @@ void Display::drawBitmapData(int16_t x, int16_t y, int16_t w, int16_t h, const u
     /** 4bpp fast version */
 
     if (m_colordepth==8) {
-	int16_t scrx,scry,xclip,xjump,scrxjump;
-    xclip=xjump=scrxjump=0;
+    int16_t scrx,scry,scrxjump;
+    int16_t xjump=0;
     /** y clipping */
     if (y<0) { h+=y; bitmap -= y*w; y=0;}
     else if (y+h>height) { h -=(y-height);}
     /** x clipping */
-    if (x<0) { xclip=x; w+=x; xjump = (-x); bitmap += xjump; x=0;}
+    if (x<0) { w+=x; xjump = (-x); bitmap += xjump; x=0;}
     else if (x+w>width) {
-            xclip = x;
-            scrxjump = x;
-            xjump=(x+w-width)+scrxjump;
+            xjump=(x+w-width);
             w = width-x;}
 
     uint8_t* scrptr = m_scrbuf + (y*width + x);
@@ -1630,8 +1628,8 @@ void Display::drawBitmapData(int16_t x, int16_t y, int16_t w, int16_t h, const u
                     bitmap++;
                     scrptr++;
                 }
-            bitmap += xjump; // needed if x<0 clipping occurs
-        scrptr = scrptr + (width - w)+scrxjump;
+            bitmap += xjump; // needed if horizontal clipping occurs
+            scrptr = scrptr + (width - w);
     }
     return;
     }

--- a/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
@@ -1793,11 +1793,8 @@ void Display::drawRleBitmap(int16_t x, int16_t y, const uint8_t* rlebitmap)
     } // end for scry
 }
 
-void Display::drawBitmapXFlipped(int16_t x, int16_t y, const uint8_t* bitmap)
+void Display::drawBitmapDataXFlipped(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t* bitmap)
 {
-    int16_t w = *bitmap;
-	int16_t h = *(bitmap + 1);
-    bitmap = bitmap + 2; //add an offset to the pointer to start after the width and height
     /** visibility check */
     if (y<-h || y>height) return; //invisible
     if (x<-w || x>width) return;  //invisible
@@ -1916,6 +1913,11 @@ void Display::drawBitmapXFlipped(int16_t x, int16_t y, const uint8_t* bitmap)
             // increment the y jump in the scrptr
             scrptr = scrptr + ((width - w)>>1)+scrxjump;
     }
+}
+
+void Display::drawBitmapXFlipped(int16_t x, int16_t y, const uint8_t* bitmap)
+{
+    drawBitmapDataXFlipped(x, y, bitmap[0], bitmap[1], bitmap + 2);
 }
 
 void Display::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t rotation, uint8_t flip) {

--- a/Pokitto/POKITTO_CORE/PokittoDisplay.h
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.h
@@ -314,6 +314,8 @@ public:
     static void drawRleBitmap(int16_t x, int16_t y, const uint8_t* bitmap);
     /** Draw animated bitmap frame */
     static void drawBitmap(int16_t x, int16_t y, const uint8_t* bitmap, uint8_t frame);
+    /** Draw bitmap data flipped on x-axis*/
+    static void drawBitmapDataXFlipped(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t* bitmap);
     /** Draw bitmap flipped on x-axis*/
     static void drawBitmapXFlipped(int16_t x, int16_t y, const uint8_t* bitmap);
     /** Draw bitmap with options */

--- a/Pokitto/POKITTO_CORE/PokittoPalette.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoPalette.cpp
@@ -46,7 +46,7 @@ Software License Agreement (BSD License)
 #include "SimLCD.h"
 #endif
 
-#if !defined(PROJ_MODE13) && !defined(PROJ_MODE64)
+#if PROJ_SCREENMODE != 13 && PROJ_SCREENMODE != 64 && !defined(PROJ_MODE13) && !defined(PROJ_MODE64)
 #define PALSIZE 16
 #else
 #define PALSIZE 256


### PR DESCRIPTION
When a sprite was going outside of the screen on the right side some artifacts were visible. This was due to uneeded offset of the screen buffer pointer (srcxjump). Also removed unused xclip local variable. Also the palette size was not correctly set to 256 when using new PROJ_SCREENMODE define.

(there is an extra commit that adds an utility method not related to mode 13, sorry about that)