### PR TITLE
Streaming audio fixes

### DIFF
--- a/Examples/PlaySFX/My_settings.h
+++ b/Examples/PlaySFX/My_settings.h
@@ -2,11 +2,11 @@
 #ifndef MY_SETTINGS_H
 #define MY_SETTINGS_H
 
-#define PROJ_ENABLE_SOUND 1     // 0 = all sound functions disabled
-#define PROJ_STREAMING_MUSIC 1
 //#define PROJ_HIGH_RAM HIGH_RAM_MUSIC // put music buffers in SRAM1/2
 //#define PROJ_SDFS_STREAMING
 #define PROJ_AUD_FREQ 8000
+#define PROJ_ENABLE_SFX
+//#define PROJ_ENABLE_SD_MUSIC
 //
 #define PROJ_BUTTONS_POLLING_ONLY //use only polling (no interrupts) for buttons
 

--- a/Pokitto/POKITTO_CORE/PokittoSound.h
+++ b/Pokitto/POKITTO_CORE/PokittoSound.h
@@ -109,18 +109,22 @@ public:
     static uint8_t sfxBytePos;
     static bool sfxIs4bitSamples;
     static void playSFX( const uint8_t *sfx, uint32_t length ){
+        #if POK_STREAMING_MUSIC > 0
         streamon=1; // force enable stream
         sfxIs4bitSamples = false;
         sfxDataPtr = sfx;
         sfxEndPtr = sfx + length;
         sfxBytePos = 0;
+        #endif
     };
     static void playSFX4bit( const uint8_t *sfx, uint32_t length ){
+        #if POK_STREAMING_MUSIC > 0
         streamon=1; // force enable stream
         sfxIs4bitSamples = true;
         sfxDataPtr = sfx;
         sfxEndPtr = sfx + length;
         sfxBytePos = 0;
+        #endif
     };
 
 	static void begin();

--- a/Pokitto/POKITTO_HW/HWSound.cpp
+++ b/Pokitto/POKITTO_HW/HWSound.cpp
@@ -436,7 +436,12 @@ inline void pokSoundIRQ() {
         #endif // POK_STREAMFREQ_HALVE
         streamstep &= streamon; // streamon is used to toggle SD music streaming on and off
         if (streamstep) {
+
+            #ifdef PROJ_DISABLE_SD_STREAMING
+            output = 0;
+            #else
             output = (*currentPtr++);
+            #endif
 
             // If exists, mix the sound effect to the output.
             if( Pokitto::Sound::sfxDataPtr != Pokitto::Sound::sfxEndPtr ){
@@ -455,15 +460,14 @@ inline void pokSoundIRQ() {
                     sfxSample = (*Pokitto::Sound::sfxDataPtr++);  // 8-bit sample
                 }
 
-                #ifdef PROJ_DISABLE_MIXING_SFX_WITH_SD_STREAMING
-                int32_t s = int32_t(sfxSample) - 1;
+                #ifdef PROJ_DISABLE_SD_STREAMING
+                output = int32_t(sfxSample);
                 #else
                 int32_t s = (int32_t(output) + int32_t(sfxSample)) - 128;
-                #endif
-
                 if( s < 0 ) s = 0;
                 else if( s > 255 ) s = 255;
                 output = s;
+                #endif
             }
 
             if(streamvol && streamon) {
@@ -473,13 +477,15 @@ inline void pokSoundIRQ() {
                 streambyte = 0; // duty cycle
                 output = 0;
             }
-            if (currentPtr >= endPtr)
-            {
-            currentBuffer++;
-            if (currentBuffer==4) currentBuffer=0;
-            currentPtr = buffers[currentBuffer];
-            endPtr = currentPtr + BUFFER_SIZE;
+
+            #ifndef PROJ_DISABLE_SD_STREAMING
+            if (currentPtr >= endPtr) {
+                currentBuffer++;
+                if (currentBuffer==4) currentBuffer=0;
+                currentPtr = buffers[currentBuffer];
+                endPtr = currentPtr + BUFFER_SIZE;
             }
+            #endif
         }
     #endif // POK_STREAMING_MUSIC
 

--- a/Pokitto/Pokitto_settings.h
+++ b/Pokitto/Pokitto_settings.h
@@ -79,6 +79,29 @@
     //#define NUM_CHANNELS 2
 #endif
 
+#ifdef PROJ_ENABLE_SFX
+	#ifndef PROJ_ENABLE_SOUND
+		#define PROJ_ENABLE_SOUND 1
+	#endif
+
+	#ifndef PROJ_STREAMING_MUSIC
+		#define PROJ_STREAMING_MUSIC 1
+	#endif
+
+	#ifndef PROJ_ENABLE_SD_MUSIC
+		#define PROJ_DISABLE_SD_STREAMING 1
+	#endif
+#endif
+
+#ifdef PROJ_ENABLE_SD_MUSIC
+	#ifndef PROJ_ENABLE_SOUND
+		#define PROJ_ENABLE_SOUND 1
+	#endif
+
+	#ifndef PROJ_STREAMING_MUSIC
+		#define PROJ_STREAMING_MUSIC 1
+	#endif
+#endif
 
 #ifndef PROJ_STREAMING_MUSIC
         #define POK_STREAMING_MUSIC 0 // Define true to stream music from SD


### PR DESCRIPTION
Fixes to streaming audio.
New macros which can replace the old ones:
#define PROJ_ENABLE_SFX
#define PROJ_ENABLE_SD_MUSIC