### PR TITLE
Remove ambiguous references to byte type

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoCore.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoCore.cpp
@@ -1170,8 +1170,8 @@ if (display.color>3) display.color=1;
 			display.textWrap = false;
 			uint16_t fc,bc;
 			fc = display.color;
-            bc = display.bgcolor;
-			for (byte i = 0; i < length; i++) {
+                        bc = display.bgcolor;
+			for (uint8_t i = 0; i < length; i++) {
 				display.cursorY = currentY + rowh * i;
 				if (i == activeItem){
 					display.cursorX = 3;
@@ -1242,7 +1242,7 @@ void Core::keyboard(char* text, uint8_t length) {
 			//type character
 			if (buttons.pressed(BTN_A)) {
 				if (activeChar < (length-1)) {
-					byte thisChar = activeX + KEYBOARD_W * activeY;
+					int thisChar = activeX + KEYBOARD_W * activeY;
 					if((thisChar == 0)||(thisChar == 10)||(thisChar == 13)) //avoid line feed and carriage return
 					continue;
 					text[activeChar] = thisChar;

--- a/Pokitto/POKITTO_LIBS/ImageFormat/BmpImage.cpp
+++ b/Pokitto/POKITTO_LIBS/ImageFormat/BmpImage.cpp
@@ -309,7 +309,7 @@ int directDrawImageFileFromSD(int16_t sx, int16_t sy, char* filepath) {
     return(directDrawImageFileFromSD(0, 0, 0/* full width */, 0/* full height */, sx, sy, filepath));
 }
 
-int directDrawImageFileFromSD(uint16_t ix, uint16_t iy, uint16_t iw, uint16_t ih, int16_t sx, int16_t sy, char* filepath) {
+int directDrawImageFileFromSD(uint16_t ix, uint16_t iy, uint16_t iw, uint16_t ih, int sx, int sy, char* filepath) {
 
     BITMAPFILEHEADER bf;
     BITMAPINFO bmi;

--- a/Pokitto/POKITTO_LIBS/Synth/Synth.h
+++ b/Pokitto/POKITTO_LIBS/Synth/Synth.h
@@ -146,12 +146,12 @@ extern uint16_t xorshift16();
 
 extern uint16_t noiseval;
 
-extern void setOSC(OSC*,byte, byte, byte, byte, byte,
+extern void setOSC(OSC*, uint8_t, uint8_t, uint8_t, uint8_t, uint8_t,
             uint8_t, uint16_t,
             uint16_t, uint16_t, uint16_t, uint16_t,
             int16_t, int16_t, uint8_t, uint8_t, uint8_t);
 
-extern void setOSC(OSC*,byte,byte,uint16_t, uint8_t, uint32_t);
+extern void setOSC(OSC*,uint8_t,uint8_t,uint16_t, uint8_t, uint32_t);
 
 extern void waveoff(OSC*);
 #endif // SYNTH_H

--- a/Pokitto/POKITTO_LIBS/Synth/Synth_osc.h
+++ b/Pokitto/POKITTO_LIBS/Synth/Synth_osc.h
@@ -23,16 +23,14 @@
 
 #include "Pokitto.h"
 
-typedef uint8_t byte;
-
 struct OSC {
-  byte on;
-  byte wave;
-  byte loop;
-  byte echo;
-  byte echodiv;
-  byte adsr;
-  byte tonic;
+  uint8_t on;
+  uint8_t wave;
+  uint8_t loop;
+  uint8_t echo;
+  uint8_t echodiv;
+  uint8_t adsr;
+  uint8_t tonic;
 
   //uint16_t count;
   uint32_t count;

--- a/Pokitto/POKITTO_LIBS/Synth/Synth_oscfuncs.cpp
+++ b/Pokitto/POKITTO_LIBS/Synth/Synth_oscfuncs.cpp
@@ -38,7 +38,7 @@
 
 /** OSCILLATOR FUNCTIONS **/
 
-void setOSC(OSC* o,byte on=1, byte wave=1, byte loop=0, byte echo=0, byte adsr=0,
+void setOSC(OSC* o,uint8_t on=1, uint8_t wave=1, uint8_t loop=0, uint8_t echo=0, uint8_t adsr=0,
             uint8_t notenumber=25, uint16_t volume=127,
             uint16_t attack=0, uint16_t decay=0, uint16_t sustain=0, uint16_t release=0,
             int16_t maxbend=0, int16_t bendrate=0, uint8_t arpmode = 0, uint8_t overdrive=0, uint8_t kick=0){
@@ -99,7 +99,7 @@ void setOSC(OSC* o,byte on=1, byte wave=1, byte loop=0, byte echo=0, byte adsr=0
   }
 }
 
-void setOSC(OSC* o,byte on, byte wave, uint16_t frq, uint8_t volume, uint32_t duration){
+void setOSC(OSC* o,uint8_t on, uint8_t wave, uint16_t frq, uint8_t volume, uint32_t duration){
   o->on = on;
   o->overdrive = 0;
   o->kick = 0;

--- a/Pokitto/POKITTO_LIBS/Synth/Synth_song.h
+++ b/Pokitto/POKITTO_LIBS/Synth/Synth_song.h
@@ -27,14 +27,14 @@ extern uint8_t chunk[2][CHUNKSIZE];
 extern uint8_t cc; // current chunk
 
 struct SONG {
-    byte rb_version; // rbtracker version with which the song was created
+    uint8_t rb_version; // rbtracker version with which the song was created
     uint16_t song_bpm; // song beats per minute
-    byte num_patches; // how many different instruments ie patches
-    byte num_channels; // how many channels are used by this song (1-3)
-    byte num_patterns; // how many different patterns are used
-    byte song_end;  // at what position song ends
+    uint8_t num_patches; // how many different instruments ie patches
+    uint8_t num_channels; // how many channels are used by this song (1-3)
+    uint8_t num_patterns; // how many different patterns are used
+    uint8_t song_end;  // at what position song ends
     int8_t song_loop; // where to loop at end of song. -1 means no loop
-    byte block_sequence[3][10]; //the sequence of blocks for each track
+    uint8_t block_sequence[3][10]; //the sequence of blocks for each track
     const uint8_t * instrument_stream[3]; //pointers to the instruments in the track streams
     const uint8_t * note_stream[3]; //pointers to the notes in the track streams
 };


### PR DESCRIPTION
C++17 has an `std::byte` type, which mbed.h makes global with `using namespace std;`.
To resolve the conflict, all the `byte` variables were changed to `uint8_t`.