### PR TITLE
Save more ram flash + fix some bugs

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoBattery.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoBattery.cpp
@@ -45,7 +45,7 @@ uint16_t Battery::thresholds[NUM_LVL];
 uint8_t  Battery::nextUpdate;
 
 #ifndef POK_SIM
-AnalogIn BatLevelPin(P0_23);
+AnalogIn Battery::BatLevelPin(P0_23);
 #endif
 
 void Battery::begin() {

--- a/Pokitto/POKITTO_CORE/PokittoBattery.h
+++ b/Pokitto/POKITTO_CORE/PokittoBattery.h
@@ -55,6 +55,10 @@ public:
     static uint16_t voltage;
     static uint16_t thresholds[NUM_LVL];
     static uint8_t  nextUpdate;
+private:
+#ifndef POK_SIM
+    static AnalogIn BatLevelPin;
+#endif
 };
 }
 

--- a/Pokitto/POKITTO_CORE/PokittoConsole.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoConsole.cpp
@@ -34,10 +34,13 @@
 */
 /**************************************************************************/
 
+
 #include "PokittoGlobs.h"
 #include "PokittoConsole.h"
 #include "PokittoFonts.h"
 #include "PokittoDisplay.h"
+
+#if (POK_USE_CONSOLE > 0)
 
 Pokitto::Console pConsole;
 
@@ -308,6 +311,6 @@ void Console::Draw() {
 }
 
 
-
+#endif
 
 

--- a/Pokitto/POKITTO_CORE/PokittoCore.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoCore.cpp
@@ -36,7 +36,11 @@
 
 #include "Pokitto_settings.h"
 #include "PokittoCore.h"
-#include "PokittoConsole.h"
+
+#if POK_USE_CONSOLE > 0
+    #include "PokittoConsole.h"
+#endif
+
 #include "PokittoFonts.h"
 #include "PokittoTimer.h"
 #include "PokittoLogos.h"
@@ -145,9 +149,12 @@ using namespace Pokitto;
 bool Core::run_state; // this definition needed
 
 /** Components */
-Backlight Core::backlight;
+#if (PROJ_GAMEBUINO > 0)
+    Backlight Core::backlight;
+    Battery Core::battery;
+#endif
+
 Buttons Core::buttons;
-Battery Core::battery;
 #if POK_ENABLE_SOUND > 0
 Sound Core::sound;
 #endif
@@ -470,7 +477,7 @@ void Core::setVolLimit() {
     //sound.setMaxVol(VOLUME_HEADPHONE_MAX);
     int dstate=1;
     bool wipe = true;
-    float vol = sound.getVolume();
+    uint16_t vol = sound.getVolume();
     //#ifndef POK_SIM
     vol=eeprom_read_byte((uint16_t*)EESETTINGS_VOL);
     Pokitto::Sound::globalVolume=vol;
@@ -608,14 +615,19 @@ void Core::begin() {
 	//frameCount = 0;
 	frameEndMicros = 1;
 	startMenuTimer = 255;
+
 	//read default settings from flash memory (set using settings.hex)
 	readSettings();
+#if (PROJ_GAMEBUINO > 0)
 	//init everything
 	backlight.begin();
 	backlight.set(BACKLIGHT_MAX);
+#endif
 	buttons.begin();
 	buttons.update();
+#if (PROJ_GAMEBUINO > 0)
 	battery.begin();
+#endif
 	display.begin();
 
 	char logoFlag = eeprom_read_byte((uint16_t*)EESETTINGS_SKIPINTRO);
@@ -688,12 +700,14 @@ void Core::begin() {
     	#endif
 	#if POK_ENABLE_SOUND > 0
         sound.begin();
-
+#if (PROJ_GAMEBUINO > 0)
 	//mute when B is held during start up or if battery is low
 	battery.update();
+#endif
 	if(buttons.pressed(BTN_B)){
 		sound.setVolume(0);
 	}
+
 	else{ //play the startup sound on each channel for it to be louder
 		#if POK_GBSOUND > 0
 		#if(NUM_CHANNELS > 0)
@@ -796,6 +810,7 @@ void Core::showLogo() {
     }
 }
 
+
 void Core::readSettings() {
     // ToDo
         /*display.contrast = SCR_CONTRAST;
@@ -815,6 +830,7 @@ void Core::readSettings() {
 		battery.thresolds[3] = BAT_LVL_FULL;*/
 }
 
+#if (PROJ_GAMEBUINO > 0)
 void Core::titleScreen(const char* name){
 	titleScreen(name, 0);
 }
@@ -827,6 +843,7 @@ void Core::titleScreen(){
 	titleScreen((""));
 }
 
+
 void Core::titleScreen(const char*  name, const uint8_t *logo){
 	display.setFont(font5x7);
 	while(buttons.aBtn()) wait(10); //don't accidentally skip menu
@@ -834,6 +851,7 @@ void Core::titleScreen(const char*  name, const uint8_t *logo){
 		display.fontSize = 1;
 		display.textWrap = false;
 		display.persistence = false;
+
 		battery.show = false;
 		display.setColor(BLACK);
 		while(isRunning()){
@@ -888,8 +906,10 @@ void Core::titleScreen(const char*  name, const uint8_t *logo){
 			}
 		}
 		battery.show = true;
+
 	}
 }
+#endif
 
 /**
  * Update all the subsystems, like graphics, audio, events, etc.
@@ -914,9 +934,13 @@ bool Core::update(bool useDirectMode, uint8_t updRectX, uint8_t updRectY, uint8_
 		frameCount++;
 
 		frameEndMicros = 0;
+#if (PROJ_GAMEBUINO > 0)
 		backlight.update();
+#endif
 		buttons.update();
+#if (PROJ_GAMEBUINO > 0)
 		battery.update();
+#endif
 
         // FPS counter
 		#if defined(PROJ_USE_FPS_COUNTER) ||  defined(PROJ_SHOW_FPS_COUNTER)
@@ -935,6 +959,7 @@ bool Core::update(bool useDirectMode, uint8_t updRectX, uint8_t updRectY, uint8_
 
 	} else {
 		if (!frameEndMicros) { //runs once at the end of the frame
+        #if (PROJ_GAMEBUINO > 0)
 			#if POK_ENABLE_SOUND > 0
 			sound.updateTrack();
 			sound.updatePattern();
@@ -942,7 +967,7 @@ bool Core::update(bool useDirectMode, uint8_t updRectX, uint8_t updRectY, uint8_
 			#endif
 			updatePopup();
 			displayBattery();
-
+        #endif
             display.update(useDirectMode, updRectX, updRectY, updRectW, updRectH); //send the buffer to the screen
 
             frameEndMicros = 1; //jonne
@@ -952,6 +977,7 @@ bool Core::update(bool useDirectMode, uint8_t updRectX, uint8_t updRectY, uint8_
 	}
 }
 
+#if (PROJ_GAMEBUINO > 0)
 void Core::displayBattery(){
 #if (ENABLE_BATTERY > 0)
 	//display.setColor(BLACK, WHITE);
@@ -992,6 +1018,7 @@ display.cursorX = ox;
 display.cursorY = oy;
 #endif
 }
+
 
 char* Core::filemenu(char *ext) {
     uint8_t oldPersistence = display.persistence;
@@ -1351,11 +1378,14 @@ void Core::updatePopup(){
 	}
 #endif
 }
+#endif //#if (PROJ_GAMEBUINO > 0)
 
 void Core::setFrameRate(uint8_t fps) {
 	timePerFrame = 1000 / fps;
+#if (PROJ_GAMEBUINO > 0)
 	sound.prescaler = fps / 20;
 	sound.prescaler = __avrmax(1, sound.prescaler);
+#endif
 }
 
 uint8_t Core::getFrameRate() {

--- a/Pokitto/POKITTO_CORE/PokittoCore.h
+++ b/Pokitto/POKITTO_CORE/PokittoCore.h
@@ -165,9 +165,9 @@ public:
 
 private:
   /** Backlight PWM pointer */
-  #ifndef POK_SIM
-  static pwmout_t backlightpwm;
-  #endif
+  //#ifndef POK_SIM
+  //static pwmout_t backlightpwm;
+  //#endif
 
   // TIMEKEEPING
 public:

--- a/Pokitto/POKITTO_CORE/PokittoCore.h
+++ b/Pokitto/POKITTO_CORE/PokittoCore.h
@@ -56,8 +56,12 @@
 #include "PokittoPalettes.h"
 #include "PokittoDisplay.h"
 #include "PokittoButtons.h"
+
+#if (PROJ_GAMEBUINO > 0)
 #include "PokittoBattery.h"
 #include "PokittoBacklight.h"
+#endif
+
 #include "PokittoSound.h"
 #include "PokittoFakeavr.h"
 
@@ -109,13 +113,16 @@ public:
   /** Create a Core runtime instance
   */
   Core();
-
+#if (PROJ_GAMEBUINO > 0)
   /** Backlight component of the Core runtime */
   static Backlight backlight;
+#endif
   /** Buttons component of the Core runtime */
   static Buttons buttons;
+#if (PROJ_GAMEBUINO > 0)
   /** Battery component of the Core runtime */
   static Battery battery;
+#endif
   /** Sound component of the Core runtime */
   static Sound sound;
   /** Display component of the Core runtime */
@@ -222,8 +229,8 @@ public:
 public:
     static void readSettings();
     static void titleScreen(const char* name, const uint8_t *logo);
-	static void titleScreen(const char* name);
-	static void titleScreen(const uint8_t* logo);
+    static void titleScreen(const char* name);
+	  static void titleScreen(const uint8_t* logo);
     static void titleScreen();
     static bool update(bool useDirectMode=false, uint8_t updRectX=0, uint8_t updRectY=0, uint8_t updRectW=LCDWIDTH, uint8_t updRectH=LCDHEIGHT);
     static uint32_t frameCount;
@@ -234,13 +241,13 @@ public:
     static void popup(const char* text, uint8_t duration);
     static void setFrameRate(uint8_t fps);
     static uint8_t getFrameRate();	
-	static void pickRandomSeed();
+	  static void pickRandomSeed();
 
-	static uint8_t getCpuLoad();
+	  static uint8_t getCpuLoad();
     static uint16_t getFreeRam();
 
     static bool collidePointRect(int16_t x1, int16_t y1 ,int16_t x2 ,int16_t y2, int16_t w, int16_t h);
-	static bool collideRectRect(int16_t x1, int16_t y1, int16_t w1, int16_t h1 ,int16_t x2 ,int16_t y2, int16_t w2, int16_t h2);
+	  static bool collideRectRect(int16_t x1, int16_t y1, int16_t w1, int16_t h1 ,int16_t x2 ,int16_t y2, int16_t w2, int16_t h2);
     static bool collideBitmapBitmap(int16_t x1, int16_t y1, const uint8_t* b1, int16_t x2, int16_t y2, const uint8_t* b2);
 
 private:

--- a/Pokitto/POKITTO_CORE/PokittoDisk.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoDisk.cpp
@@ -45,7 +45,9 @@ bool diropened=false;
 #define FILESIZE 0x1BFBCD
 
 uint8_t filemode = FILE_MODE_UNINITIALIZED;
-char currentfile[15]; // holds current file's name
+
+#define CURRENT_FILE_SIZE 15
+char currentfile[CURRENT_FILE_SIZE]; // holds current file's name
 
 SPI device(CONNECT_MOSI,CONNECT_MISO,CONNECT_SCK);
 //DigitalOut mmccs(CONNECT_CS);
@@ -220,8 +222,14 @@ uint8_t fileOpen(char* buffer, char fmode) {
     filemode = fmode;
     err = PFFS::pf_open(buffer);
     if (err==0) {
-            strcpy(currentfile,(const char*)buffer);
-            return 0; // 0 means all clear
+        uint8_t i=0;
+        while(buffer[i] && i < CURRENT_FILE_SIZE-1 )
+        {
+            currentfile[i]=buffer[i];
+            i++;
+        }
+        currentfile[i]=0;
+        return 0; // 0 means all clear
     }
     // file open failed
     filemode = FILE_MODE_FAILED;
@@ -230,7 +238,7 @@ uint8_t fileOpen(char* buffer, char fmode) {
 
 void fileClose() {
     filemode = FILE_MODE_UNINITIALIZED;
-    for (uint8_t i=0; i<15; i++) currentfile[i]=0;
+    for (uint8_t i=0; i<CURRENT_FILE_SIZE; i++) currentfile[i]=0;
 }
 
 char fileGetChar() {

--- a/Pokitto/POKITTO_CORE/PokittoDisplay.h
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.h
@@ -119,10 +119,10 @@ enum defcolors {
 
 const uint16_t def565palette[16] = {
     //kind of like pico8 palette
-    0,0x194a,0x792a,0x42a,
-    0xaa86,0x5aa9,0xc618,0xff9d,
-    0xf809,0xfd00,0xff84,0x72a,
-    0x2d7f,0x83b3,0xfbb5,0xfe75
+    0x0000, 0x194a, 0x792a, 0x042a,
+    0xaa86, 0x5aa9, 0xc618, 0xff9d,
+    0xf809, 0xfd00, 0xff84, 0x072a,
+    0x2d7f, 0x83b3, 0xfbb5, 0xfe75
 };
 
 #if ((POK_SCREENMODE==MODE_FAST_16COLOR) || (POK_SCREENMODE==MODE15) || (POK_SCREENMODE==MODE_HI_16COLOR))
@@ -144,16 +144,20 @@ public:
 
     // PROPERTIES
 private:
-    static uint8_t* canvas;
-    static uint8_t bpp;
+    //static uint8_t* canvas;
+    //static uint8_t bpp;
 public:
     static uint8_t m_colordepth; // public to be used elsewhere
+#if (POK_SCREENMODE == MIXMODE)
     static uint8_t subMode; // for mixed mode switching
+#endif
     static uint8_t palOffset;
     static uint8_t width;
     static uint8_t height;
     static uint8_t screenbuffer[];
+#if (POK_SCREENMODE == MIXMODE)
     static uint8_t scanType[]; // for mixed screen mode
+#endif
 
     // PROPERTIES
     static void setColorDepth(uint8_t);
@@ -180,11 +184,13 @@ public:
     static uint16_t directbgcolor;
     /** Direct text rotated */
     static bool directtextrotated;
+    #if (POK_COLORDEPTH == 2)
     /** clip rect on screen**/
     static int16_t clipX;
     static int16_t clipY;
     static int16_t clipW;
     static int16_t clipH;
+    #endif
     /** set color with a command */
     static void setColor(uint8_t);
     /** set color and bgcolor with a command */
@@ -197,8 +203,11 @@ public:
     static uint8_t getBgColor();
     /** get invisible color */
     static uint16_t getInvisibleColor();
+
+    #if (POK_COLORDEPTH == 2)
     /** set clip rect on screen**/
     static void setClipRect(int16_t x, int16_t y, int16_t w, int16_t h);
+    #endif
 
     /** Initialize display */
     static void begin();
@@ -458,6 +467,7 @@ public:
     /** external small printf, source in PokittoPrintf.cpp **/
     static int printf(const char *format, ...);
 
+#if (POK_SCREENMODE == MODE_TILED_1BIT)
     /** Tiled mode functions **/
 
     static void loadTileset(const uint8_t*);
@@ -469,20 +479,23 @@ public:
     static void setTile(uint16_t,uint8_t);
     static uint8_t getTile(uint16_t);
     static uint8_t getTile(uint8_t,uint8_t);
-
+#endif
 
 
 private:
     static uint8_t m_mode;
-    static uint16_t m_w,m_h; // store these for faster access when switching printing modes
+    static uint8_t m_w,m_h; // store these for faster access when switching printing modes
     /** Pointer to screen buffer */
     static uint8_t* m_scrbuf;
+
+#if (POK_SCREENMODE == MODE_TILED_1BIT)
     /** Pointer to tileset */
     static uint8_t* m_tileset;
     /** Pointer to tilebuffer */
     static uint8_t* m_tilebuf;
     /** Pointer to tilecolorbuffer */
     static uint8_t* m_tilecolorbuf;
+#endif
 
     /** Sprites */
 #if (POK_SCREENMODE == MODE_HI_4COLOR)

--- a/Pokitto/POKITTO_CORE/PokittoSound.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoSound.cpp
@@ -948,13 +948,8 @@ int Sound::playMusicStream(char* filename, uint8_t options)
 
         uint8_t result;
         result = pokInitSD();
-        if (!isThisFileOpen(filename)) {
-            fileClose(); // close any open files
-            result = fileOpen(filename,FILE_MODE_READONLY | FILE_MODE_BINARY);
-        }else{
-	    fileRewind();
-	    result = 0;
-	}
+        fileClose(); // close any open files
+        result = fileOpen(filename,FILE_MODE_READONLY | FILE_MODE_BINARY);
 
         if (result) {
                 currentPtr = 0; // mark that no stream is available

--- a/Pokitto/POKITTO_CORE/PokittoSound.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoSound.cpp
@@ -43,7 +43,7 @@
  *
  * License for Gamebuino-identical code:
  *
- * (C) Copyright 2014 Aurélien Rodot. All rights reserved.
+ * (C) Copyright 2014 Aurï¿½lien Rodot. All rights reserved.
  *
  * This file is part of the Gamebuino Library (http://gamebuino.com)
  *
@@ -64,7 +64,9 @@
 #include "PokittoSound.h"
 #include "Pokitto_settings.h"
 #include "PokittoCore.h"
+#if (POK_ENABLE_SYNTH == 1)
 #include "Synth.h"
+#endif
 
 #ifndef POK_SIM
 #include "HWSound.h"
@@ -100,10 +102,13 @@ const uint8_t *Sound::sfxEndPtr = 0;
 bool Sound::sfxIs4bitSamples = false;
 uint8_t Sound::sfxBytePos = 0;
 
-uint8_t Sound::prescaler;
 uint16_t Sound::globalVolume;
 uint16_t Sound::volumeMax = VOLUME_HEADPHONE_MAX;
 uint8_t Sound::headPhoneLevel=1;
+
+#if (POK_GBSOUND > 0)
+
+uint8_t Sound::prescaler;
 
 bool Sound::trackIsPlaying[NUM_CHANNELS];
 bool Sound::patternIsPlaying[NUM_CHANNELS];
@@ -148,6 +153,8 @@ int8_t Sound::stepVolume[NUM_CHANNELS];
 uint8_t Sound::stepPitch[NUM_CHANNELS];
 uint8_t Sound::chanVolumes[NUM_CHANNELS];
 
+#endif
+
 #if (POK_ENABLE_SOUND < 1)
  #ifdef NUM_CHANNELS
  #undef NUM_CHANNELS
@@ -181,6 +188,7 @@ const uint16_t playOKPattern[]  = {0x0005,0x138,0x168,0x0000};
 const uint16_t playCancelPattern[]  = {0x0005,0x168,0x138,0x0000};
 const uint16_t playTickP[]  = {0x0045,0x168,0x0000};
 #endif
+
 #if(EXTENDED_NOTE_RANGE > 0)
 //extended note range
 #define NUM_PITCH 59
@@ -219,7 +227,7 @@ void Pokitto::audio_IRQ() {
         }
 
     #endif // POK_STREAMING_MUSIC
-    #if (NUM_CHANNELS > 0)
+    #if (NUM_CHANNELS > 0) && (PROJ_GAMEBUINO > 0)
 	Sound::generateOutput();
     #endif
 }
@@ -301,6 +309,8 @@ ampEnable(true);
 #endif //POK_ENABLE_SOUND
 #endif
 }
+
+#if (POK_GBSOUND > 0)
 
 void Sound::playTrack(const uint16_t* track, uint8_t channel){
 #if(NUM_CHANNELS > 0)
@@ -757,7 +767,7 @@ void Sound::updateOutput() {
     #if POK_ENABLE_SOUND
     /** HARDWARE **/
 
-        #if POK_STREAMING_MUSIC
+        #if POK_STREAMING_MUSIC && POK_USE_PWM
             if (streamstep) {
                 //pwmout_write(&audiopwm,(float)(sbyte>>headPhoneLevel)/(float)255);
                 sbyte *= discrete_vol_multipliers[discrete_vol];
@@ -817,6 +827,8 @@ void Sound::playTick(){
 #endif // POK_GBSOUND
 }
 
+#endif //(POK_GBSOUND > 0)
+
 void Sound::setVolume(int16_t volume) {
 //#if NUM_CHANNELS > 0
 	if (volume<0) volume = 0;
@@ -844,6 +856,7 @@ uint16_t Sound::getVolume() {
 //#endif
 }
 
+#if (POK_GBSOUND > 0)
 void Sound::setVolume(int8_t volume, uint8_t channel) {
 #if(NUM_CHANNELS > 0)
 	if(channel>=NUM_CHANNELS)
@@ -863,7 +876,9 @@ uint8_t Sound::getVolume(uint8_t channel) {
 	return 0;
 #endif
 }
+#endif //(POK_GBSOUND > 0)
 
+#if (POK_ENABLE_SYNTH == 1)
 void Sound::playTone(uint8_t os, int frq, uint8_t amp, uint8_t wav,uint8_t arpmode)
 {
     if (wav>MAX_WAVETYPES) wav=0;
@@ -879,6 +894,8 @@ void Sound::playTone(uint8_t os, uint16_t frq, uint8_t volume, uint32_t duration
     else if (os==2) setOSC(&osc2,1,WTRI,frq,volume,duration);
     else if (os==3) setOSC(&osc3,1,WTRI,frq,volume,duration);
 }
+
+#endif
 
 uint8_t Sound::ampIsOn()
 {
@@ -973,6 +990,7 @@ uint32_t Sound::getMusicStreamElapsedMilliSec() {
     return 0;
 }
 
+#if (POK_ENABLE_SYNTH == 1)
 void Sound::loadSampleToOsc(uint8_t os, uint8_t* data, uint32_t datasize) {
     OSC* o;
     if (os==3) o = &osc3;
@@ -982,3 +1000,4 @@ void Sound::loadSampleToOsc(uint8_t os, uint8_t* data, uint32_t datasize) {
     o->samplelength = datasize;
     o->samplepos = 0;
 }
+#endif

--- a/Pokitto/POKITTO_CORE/PokittoSound.h
+++ b/Pokitto/POKITTO_CORE/PokittoSound.h
@@ -152,6 +152,11 @@ public:
     static uint32_t getMusicStreamElapsedSec();
     static uint32_t getMusicStreamElapsedMilliSec();
 
+	static uint16_t globalVolume;
+	static void setVolume(int16_t volume);
+	static uint16_t getVolume();
+
+#if (POK_GBSOUND > 0)
 	// GB compatibility functions
 	static void playTrack(const uint16_t* track, uint8_t channel);
 	static void updateTrack(uint8_t channel);
@@ -182,8 +187,7 @@ public:
 
 	static void setMasterVolume(uint8_t);
 	static uint8_t GetMasterVolume();
-	static void setVolume(int16_t volume);
-	static uint16_t getVolume();
+
 	static void setVolume(int8_t volume, uint8_t channel);
 	static uint8_t getVolume(uint8_t channel);
 
@@ -195,8 +199,9 @@ public:
 
 	static void setChannelHalfPeriod(uint8_t channel, uint8_t halfPeriod);
 
+
 	static void generateOutput(); //!\\ DO NOT USE
-	static uint16_t globalVolume;
+
 
 
 #if (NUM_CHANNELS > 0)
@@ -241,6 +246,9 @@ public:
 
 	static uint8_t chanVolumes[NUM_CHANNELS];
 #endif
+
+#endif // Gamebuino sound
+
 	static void updateOutput();
 };
 

--- a/Pokitto/POKITTO_CORE/SDFSDisk.h
+++ b/Pokitto/POKITTO_CORE/SDFSDisk.h
@@ -4,7 +4,9 @@
 #include "SDFileSystem.h"
 
 // declared in PokittoDisk.cpp
-extern char currentfile[15]; // holds current file's name
+
+#define CURRENT_FILE_SIZE 15
+extern char currentfile[CURRENT_FILE_SIZE]; // holds current file's name
 
 // declared in SDFileSystem.cpp
 extern FileHandle *sdfsdisk_fileptr;
@@ -55,7 +57,14 @@ inline uint8_t fs_fileOpen(const char *buffer, char fmode){
     if( !sdfsdisk_fileptr )
 	return 1;
 
-    strcpy(currentfile,buffer);
+    uint8_t i=0;
+    while(buffer[i] && i < CURRENT_FILE_SIZE-1 )
+    {
+        currentfile[i]=buffer[i];
+        i++;
+    }
+    currentfile[i]=0;
+
     fs.fsize = sdfsdisk_fileptr->flen();
     return 0;
 }

--- a/Pokitto/POKITTO_CORE/SDFSDisk.h
+++ b/Pokitto/POKITTO_CORE/SDFSDisk.h
@@ -28,7 +28,7 @@ struct fs_fs_t {
 
 inline bool fs_pokInitSD(){
     if( !FATFileSystem::_ffs[0] )
-	new SDFileSystem(P0_9, P0_8, P0_6, P0_7, "streaming", NC, SDFileSystem::SWITCH_NONE, 25000000 );
+	new SDFileSystem(P0_9, P0_8, P0_6, P0_7, "sd", NC, SDFileSystem::SWITCH_NONE, 24000000 );
     return true;
 }
 

--- a/Pokitto/POKITTO_HW/HWButtons.cpp
+++ b/Pokitto/POKITTO_HW/HWButtons.cpp
@@ -53,6 +53,7 @@ InterruptIn DBtn(POK_BTN_DOWN_PIN);
 InterruptIn LBtn(POK_BTN_LEFT_PIN);
 InterruptIn RBtn(POK_BTN_RIGHT_PIN);
 #else
+/*
 DigitalIn ABtn(POK_BTN_A_PIN);
 DigitalIn BBtn(POK_BTN_B_PIN);
 DigitalIn CBtn(POK_BTN_C_PIN);
@@ -60,6 +61,17 @@ DigitalIn UBtn(POK_BTN_UP_PIN);
 DigitalIn DBtn(POK_BTN_DOWN_PIN);
 DigitalIn LBtn(POK_BTN_LEFT_PIN);
 DigitalIn RBtn(POK_BTN_RIGHT_PIN);
+*/
+
+//from minilib by FManga
+inline bool ABtn(){ return *((volatile char*)(0xA0000000 + 1*0x20 + 9)); }
+inline bool BBtn(){ return *((volatile char*)(0xA0000000 + 1*0x20 + 4)); }
+inline bool CBtn(){ return *((volatile char*)(0xA0000000 + 1*0x20 + 10)); }
+inline bool UBtn(){ return *((volatile char*)(0xA0000000 + 1*0x20 + 13)); }
+inline bool DBtn(){ return *((volatile char*)(0xA0000000 + 1*0x20 + 3)); }
+inline bool LBtn(){ return *((volatile char*)(0xA0000000 + 1*0x20 + 25)); }
+inline bool RBtn(){ return *((volatile char*)(0xA0000000 + 1*0x20 + 7)); }
+
 #endif
 
 
@@ -207,6 +219,19 @@ void Pokitto::initButtons() {
   NVIC_SetVector((IRQn_Type)(PIN_INT4_IRQn), (uint32_t)&PIN_INT4_IRQHandler);
   NVIC_SetVector((IRQn_Type)(PIN_INT5_IRQn), (uint32_t)&PIN_INT5_IRQHandler);
   NVIC_SetVector((IRQn_Type)(PIN_INT6_IRQn), (uint32_t)&PIN_INT6_IRQHandler);
+
+  #else
+  
+  //init buttons
+  using Reg = volatile unsigned int *;
+  
+  *Reg(0x40044084) = 0x88;
+  *Reg(0x40044070) = 0x88;
+  *Reg(0x40044088) = 0x88;
+  *Reg(0x40044094) = 0x88;
+  *Reg(0x4004406c) = 0x88;
+  *Reg(0x400440c4) = 0x88;
+  *Reg(0x4004407c) = 0x88;
   #endif
 }
 
@@ -215,7 +240,7 @@ uint8_t Pokitto::Core::aBtn() {
     #ifndef PROJ_BUTTONS_POLLING_ONLY
     return Pokitto::heldStates[BTN_A];
     #else
-    Pokitto::heldStates[BTN_A]=ABtn.read();
+    Pokitto::heldStates[BTN_A]=ABtn();
     return Pokitto::heldStates[BTN_A];
     #endif
 
@@ -226,7 +251,7 @@ uint8_t Pokitto::Core::bBtn() {
     #ifndef PROJ_BUTTONS_POLLING_ONLY
     return Pokitto::heldStates[BTN_B];
     #else
-    Pokitto::heldStates[BTN_B]=BBtn.read();
+    Pokitto::heldStates[BTN_B]=BBtn();
     return Pokitto::heldStates[BTN_B];
     #endif
 }
@@ -236,7 +261,7 @@ uint8_t Pokitto::Core::cBtn() {
     #ifndef PROJ_BUTTONS_POLLING_ONLY
     return Pokitto::heldStates[BTN_C];
     #else
-    Pokitto::heldStates[BTN_C]=CBtn.read();
+    Pokitto::heldStates[BTN_C]=CBtn();
     return Pokitto::heldStates[BTN_C];
     #endif
 }
@@ -246,7 +271,7 @@ uint8_t Pokitto::Core::upBtn() {
     #ifndef PROJ_BUTTONS_POLLING_ONLY
     return Pokitto::heldStates[BTN_UP];
     #else
-    Pokitto::heldStates[BTN_UP]=UBtn.read();
+    Pokitto::heldStates[BTN_UP]=UBtn();
     return Pokitto::heldStates[BTN_UP];
     #endif
 }
@@ -255,7 +280,7 @@ uint8_t Pokitto::Core::downBtn() {
     #ifndef PROJ_BUTTONS_POLLING_ONLY
     return Pokitto::heldStates[BTN_DOWN];
     #else
-    Pokitto::heldStates[BTN_DOWN]=DBtn.read();
+    Pokitto::heldStates[BTN_DOWN]=DBtn();
     return Pokitto::heldStates[BTN_DOWN];
     #endif
 }
@@ -265,7 +290,7 @@ uint8_t Pokitto::Core::leftBtn() {
     #ifndef PROJ_BUTTONS_POLLING_ONLY
     return Pokitto::heldStates[BTN_LEFT];
     #else
-    Pokitto::heldStates[BTN_LEFT]=LBtn.read();
+    Pokitto::heldStates[BTN_LEFT]=LBtn();
     return Pokitto::heldStates[BTN_LEFT];
     #endif
 }
@@ -274,7 +299,7 @@ uint8_t Pokitto::Core::rightBtn() {
     #ifndef PROJ_BUTTONS_POLLING_ONLY
     return Pokitto::heldStates[BTN_RIGHT];
     #else
-    Pokitto::heldStates[BTN_RIGHT]=RBtn.read();
+    Pokitto::heldStates[BTN_RIGHT]=RBtn();
     return Pokitto::heldStates[BTN_RIGHT];
     #endif
 }

--- a/Pokitto/POKITTO_HW/HWLCD.cpp
+++ b/Pokitto/POKITTO_HW/HWLCD.cpp
@@ -167,11 +167,8 @@ void Pokitto::setDRAMpoint(uint8_t xptr, uint8_t yoffset)
 }
 
 void Pokitto::initBacklight() {
+    #ifndef POK_EXT0_PWM_ENABLE
     #if POK_BOARDREV == 2
-    //pwmout_init(&backlightpwm,POK_BACKLIGHT_PIN);
-    //pwmout_period_us(&backlightpwm,5);
-    //pwmout_write(&backlightpwm,POK_BACKLIGHT_INITIALVALUE);
-
     LPC_SYSCON->SYSAHBCLKCTRL |= (1<<31);
     LPC_SYSCON->PRESETCTRL |=  (1 << (0 + 9));
     LPC_IOCON->PIO2_2 = (LPC_IOCON->PIO2_2 & ~(0x3FF)) | 0x3;     //set up pin for PWM use
@@ -187,12 +184,15 @@ void Pokitto::initBacklight() {
 
     setBacklight(POK_BACKLIGHT_INITIALVALUE);
     #endif
+    #else
+    pin_function(P2_2,0);//set pin function back to 0
+    LPC_GPIO_PORT->DIR[2] |= (1  << 2 );
+    LPC_GPIO_PORT->SET[2] = 1 << 2; // full background light, smaller file size
+    #endif
 }
 
 void Pokitto::setBacklight(uint8_t value) {
-    //if (value>0.999f) value = 0.999f;
-    //pwmout_write(&backlightpwm,value);
-
+    #ifndef POK_EXT0_PWM_ENABLE
     if (value>100)
         value = 100;
 
@@ -200,7 +200,7 @@ void Pokitto::setBacklight(uint8_t value) {
     LPC_SCT0->MATCHREL1 = (LPC_SCT0->MATCHREL0 * value)/100; 
 
     LPC_SCT0->CTRL &= ~(1 << 2);
-
+    #endif
 }
 
 void Pokitto::lcdInit() {

--- a/Pokitto/POKITTO_HW/HWLCD.cpp
+++ b/Pokitto/POKITTO_HW/HWLCD.cpp
@@ -53,9 +53,9 @@ using namespace Pokitto;
 
 uint16_t prevdata=0; // if data does not change, do not adjust LCD bus lines
 
-#if POK_BOARDREV == 2
-    pwmout_t backlightpwm;
-#endif
+//#if POK_BOARDREV == 2
+//    pwmout_t backlightpwm;
+//#endif
 
 volatile uint32_t *LCD = reinterpret_cast< volatile uint32_t * >(0xA0002188);
 
@@ -168,15 +168,39 @@ void Pokitto::setDRAMpoint(uint8_t xptr, uint8_t yoffset)
 
 void Pokitto::initBacklight() {
     #if POK_BOARDREV == 2
-    pwmout_init(&backlightpwm,POK_BACKLIGHT_PIN);
-    pwmout_period_us(&backlightpwm,5);
-    pwmout_write(&backlightpwm,POK_BACKLIGHT_INITIALVALUE);
+    //pwmout_init(&backlightpwm,POK_BACKLIGHT_PIN);
+    //pwmout_period_us(&backlightpwm,5);
+    //pwmout_write(&backlightpwm,POK_BACKLIGHT_INITIALVALUE);
+
+    LPC_SYSCON->SYSAHBCLKCTRL |= (1<<31);
+    LPC_SYSCON->PRESETCTRL |=  (1 << (0 + 9));
+    LPC_IOCON->PIO2_2 = (LPC_IOCON->PIO2_2 & ~(0x3FF)) | 0x3;     //set up pin for PWM use
+    LPC_SCT0->CONFIG |= ((0x3 << 17) | 0x01);
+    LPC_SCT0->CTRL |= (1 << 2) | (1 << 3);
+
+    LPC_SCT0->OUT1_SET = (1 << 0); // event 0
+    LPC_SCT0->OUT1_CLR = (1 << 1); // event 1
+    LPC_SCT0->EV0_CTRL  = (1 << 12);
+    LPC_SCT0->EV0_STATE = 0xFFFFFFFF;
+    LPC_SCT0->EV1_CTRL  = (1 << 12) | (1 << 0);
+    LPC_SCT0->EV1_STATE = 0xFFFFFFFF;
+
+    setBacklight(POK_BACKLIGHT_INITIALVALUE);
     #endif
 }
 
-void Pokitto::setBacklight(float value) {
-    if (value>0.999f) value = 0.999f;
-    pwmout_write(&backlightpwm,value);
+void Pokitto::setBacklight(uint8_t value) {
+    //if (value>0.999f) value = 0.999f;
+    //pwmout_write(&backlightpwm,value);
+
+    if (value>100)
+        value = 100;
+
+    LPC_SCT0->MATCHREL0 = 20000;
+    LPC_SCT0->MATCHREL1 = (LPC_SCT0->MATCHREL0 * value)/100; 
+
+    LPC_SCT0->CTRL &= ~(1 << 2);
+
 }
 
 void Pokitto::lcdInit() {

--- a/Pokitto/POKITTO_HW/HWLCD.h
+++ b/Pokitto/POKITTO_HW/HWLCD.h
@@ -62,7 +62,7 @@ struct SpriteInfo {
 extern void setDRAMpoint(uint8_t, uint8_t);
 extern void pumpDRAMdata(uint16_t*, uint16_t);
 extern void initBacklight();
-extern void setBacklight(float);
+extern void setBacklight(uint8_t);
 extern void lcdFillSurface(uint16_t);
 extern void lcdPixel(int16_t x, int16_t y, uint16_t c);
 extern void setWindow(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2);

--- a/Pokitto/POKITTO_HW/HWSound.h
+++ b/Pokitto/POKITTO_HW/HWSound.h
@@ -139,7 +139,10 @@ extern int setHWvolume(uint8_t);
 extern uint8_t getHWvolume();
 extern void changeHWvolume(int8_t);
 
+#if POK_USE_PWM
 extern pwmout_t audiopwm;
+#endif
+
 extern uint8_t pokAmpIsOn();
 extern void pokAmpEnable(uint8_t);
 

--- a/Pokitto/POKITTO_HW/PokittoHW.cpp
+++ b/Pokitto/POKITTO_HW/PokittoHW.cpp
@@ -48,8 +48,12 @@ void Core::quit() {
 
 void Core::initRandom() {
     time_t seconds = time(NULL);
+#if (PROJ_GAMEBUINO > 0)
     Pokitto::Battery::update();
     srand((unsigned int) (Pokitto::Battery::level + (seconds)));
+#else
+    srand((unsigned int)seconds);
+#endif
 }
 
 void Core::initGPIO() {
@@ -65,25 +69,25 @@ void Core::initGPIO() {
     /** data lines **/
     LPC_GPIO_PORT->DIR[2] |= (0xFFFF  << 3);  // P2_3...P2_18 as output
 
-    pin_mode(P2_3,PullNone); // turn off pull-up
-    pin_mode(P2_4,PullNone); // turn off pull-up
-    pin_mode(P2_5,PullNone); // turn off pull-up
-    pin_mode(P2_6,PullNone); // turn off pull-up
+    pin_mode(P2_3, PullNone); // turn off pull-up
+    pin_mode(P2_4, PullNone); // turn off pull-up
+    pin_mode(P2_5, PullNone); // turn off pull-up
+    pin_mode(P2_6, PullNone); // turn off pull-up
 
-    pin_mode(P2_7,PullNone); // turn off pull-up
-    pin_mode(P2_8,PullNone); // turn off pull-up
-    pin_mode(P2_9,PullNone); // turn off pull-up
-    pin_mode(P2_10,PullNone); // turn off pull-up
+    pin_mode(P2_7, PullNone); // turn off pull-up
+    pin_mode(P2_8, PullNone); // turn off pull-up
+    pin_mode(P2_9, PullNone); // turn off pull-up
+    pin_mode(P2_10, PullNone); // turn off pull-up
 
-    pin_mode(P2_11,PullNone); // turn off pull-up
-    pin_mode(P2_12,PullNone); // turn off pull-up
-    pin_mode(P2_13,PullNone); // turn off pull-up
-    pin_mode(P2_14,PullNone); // turn off pull-up
+    pin_mode(P2_11, PullNone); // turn off pull-up
+    pin_mode(P2_12, PullNone); // turn off pull-up
+    pin_mode(P2_13, PullNone); // turn off pull-up
+    pin_mode(P2_14, PullNone); // turn off pull-up
 
-    pin_mode(P2_15,PullNone); // turn off pull-up
-    pin_mode(P2_16,PullNone); // turn off pull-up
-    pin_mode(P2_17,PullNone); // turn off pull-up
-    pin_mode(P2_18,PullNone); // turn off pull-up
+    pin_mode(P2_15, PullNone); // turn off pull-up
+    pin_mode(P2_16, PullNone); // turn off pull-up
+    pin_mode(P2_17, PullNone); // turn off pull-up
+    pin_mode(P2_18, PullNone); // turn off pull-up
 }
 
 

--- a/Pokitto/POKITTO_HW/clock_11u6x.h
+++ b/Pokitto/POKITTO_HW/clock_11u6x.h
@@ -35,7 +35,10 @@
 #include "lpc_defs.h"
 #define STATIC static
 #define INLINE inline
+
+#ifndef bool
 #define bool unsigned char
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/Pokitto/POKITTO_HW/iap.cpp
+++ b/Pokitto/POKITTO_HW/iap.cpp
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <iap.h>
 #include "LPC11U6x.h"
-#include "PokittoDisk.h"
+//#include "PokittoDisk.h"
 
 #define TICKRATE_HZ (10)	/* 10 ticks per second */
 /* SystemTick Counter */
@@ -117,6 +117,8 @@ int CopyPageToFlash (uint32_t address, uint8_t* data) {
     return 0; /*succesful write*/
 
 }
+
+#if 0
 
 __attribute__((section(".IAP_Code"))) int HelloFromIAP() {
 	IAP iap_entry = (IAP) IAP_LOCATION;
@@ -283,7 +285,7 @@ char iaptest() {
 	return 0;
 
 }
-
+#endif
 
 //1) EEprom Write
 //
@@ -389,7 +391,7 @@ uint8_t eeprom_read_byte(uint16_t* index) {
 void eeprom_write_byte(uint16_t* index , uint8_t val) {
     writeEEPROM(index,&val,1);
 }
-
+#if 0
 /*****************************************************************************
  * $Id$
  *
@@ -741,3 +743,4 @@ __attribute__((section(".IAP_Code"))) uint32_t u32IAP_ErasePage(uint32_t u32Star
 /*****************************************************************************
  **                            End Of File
  *****************************************************************************/
+#endif

--- a/Pokitto/POKITTO_HW/iap.cpp
+++ b/Pokitto/POKITTO_HW/iap.cpp
@@ -21,15 +21,16 @@ static volatile uint32_t sysTick;
 #define IAP_ERSSECTOR_CMD 52
 #define IAP_REPID_CMD 54
 
-/* IAP command variables */
-static unsigned int command[5], result[4];
 
 /* IAP entry function */
 typedef int (*IAP)(unsigned int[], unsigned int[]);
-IAP iap_entry = (IAP) IAP_LOCATION;
+
 
 int CopyPageToFlash (uint32_t address, uint8_t* data) {
     IAP iap_call = (IAP) IAP_LOCATION;
+	/* IAP command variables */
+	unsigned int command[5], result[4];
+
     uint32_t writecount=0;
 	__disable_irq();
 
@@ -118,6 +119,10 @@ int CopyPageToFlash (uint32_t address, uint8_t* data) {
 }
 
 __attribute__((section(".IAP_Code"))) int HelloFromIAP() {
+	IAP iap_entry = (IAP) IAP_LOCATION;
+	/* IAP command variables */
+	unsigned int command[5], result[4];
+
     uint32_t array_data[WRITECOUNT];
     int i;
     /* Initialize the array data to be written to FLASH */
@@ -221,6 +226,10 @@ void IAPstacksave()
 
 
 char iaptest() {
+	IAP iap_entry = (IAP) IAP_LOCATION;
+	/* IAP command variables */
+	unsigned int command[5], result[4];
+
     uint32_t array_data[WRITECOUNT];
     int i;
     /* Initialize the array data to be written to FLASH */
@@ -287,6 +296,7 @@ char iaptest() {
 //Return Code CMD_SUCCESS | SRC_ADDR_NOT_MAPPED | DST_ADDR_NOT_MAPPED
 __attribute__((section(".IAP_Code"))) void writeEEPROM( uint16_t* eeAddress, uint8_t* buffAddress, uint32_t byteCount )
 {
+	IAP iap_entry = (IAP) IAP_LOCATION;
 	unsigned int command[5], result[4];
 
 	command[0] = 61;
@@ -325,6 +335,7 @@ __attribute__((section(".IAP_Code"))) void writeEEPROM( uint16_t* eeAddress, uin
 //Return Code CMD_SUCCESS | SRC_ADDR_NOT_MAPPED | DST_ADDR_NOT_MAPPED
 __attribute__((section(".IAP_Code"))) void readEEPROM( uint16_t* eeAddress, uint8_t* buffAddress, uint32_t byteCount )
 {
+	IAP iap_entry = (IAP) IAP_LOCATION;
 	unsigned int command[5], result[4];
 
 	command[0] = 62;
@@ -347,6 +358,8 @@ __attribute__((section(".IAP_Code"))) void readEEPROM( uint16_t* eeAddress, uint
 
 __attribute__((section(".IAP_Code"))) void IAPreadPartId( uint8_t* eeAddress, uint8_t* buffAddress, uint32_t byteCount )
 {
+	IAP iap_entry = (IAP) IAP_LOCATION;
+
 	unsigned int command[5], result[4];
 
 	command[0] = 62;

--- a/Pokitto/POKITTO_HW/timer_11u6x.h
+++ b/Pokitto/POKITTO_HW/timer_11u6x.h
@@ -40,7 +40,10 @@
 /* External data/function define */
 #define EXTERN extern
 #define INLINE inline
+
+#ifndef bool
 #define bool uint8_t
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/Pokitto/POKITTO_LIBS/MicroPython/PythonBindings.cpp
+++ b/Pokitto/POKITTO_LIBS/MicroPython/PythonBindings.cpp
@@ -220,10 +220,12 @@ void POK_game_display_setPalette(uint16_t* paletteArray, int16_t len) {
 }
 
 void Pok_Display_setClipRect(int16_t x, int16_t y, int16_t w, int16_t h) {
+#if (POK_SCREENMODE == MODE_HI_4COLOR)
     if(h == 0)
         Display::setClipRect(0, 0, LCDWIDTH, LCDHEIGHT);  // Remove clip rect
     else
         Display::setClipRect(x, y, w, h);  // Set clip rect
+#endif
 }
 
 // Draw the screen surface immediately to the display. Do not care about fps limits. Do not run event loops etc.

--- a/Pokitto/POKITTO_LIBS/MicroPython/PythonBindings.cpp
+++ b/Pokitto/POKITTO_LIBS/MicroPython/PythonBindings.cpp
@@ -198,12 +198,16 @@ void Pok_Display_blitFrameBuffer(int16_t x, int16_t y, int16_t w, int16_t h, boo
 }
 
 void Pok_Display_setSprite(uint8_t index, int16_t x, int16_t y, int16_t w, int16_t h, int16_t invisiblecol_, uint8_t *buffer, uint16_t* palette16x16bit, bool doResetDirtyRect) {
+#if (POK_SCREENMODE == MODE_HI_4COLOR)
     Display::invisiblecolor = (uint8_t)invisiblecol_;
     Display::setSprite(index, buffer, palette16x16bit, x, y, w, h, doResetDirtyRect );
+#endif
 }
 
 void Pok_Display_setSpritePos(uint8_t index, int16_t x, int16_t y) {
+#if (POK_SCREENMODE == MODE_HI_4COLOR)
     Display::setSpritePos(index, x, y);
+#endif
 }
 
 uint16_t POK_game_display_RGBto565(uint8_t r, uint8_t g, uint8_t b) {

--- a/Pokitto/POKITTO_SIM/PokittoClock.cpp
+++ b/Pokitto/POKITTO_SIM/PokittoClock.cpp
@@ -35,7 +35,11 @@ Software License Agreement (BSD License)
 /**************************************************************************/
 
 #include "PokittoCore.h"
+
+#if POK_USE_CONSOLE > 0
 #include "PokittoConsole.h"
+#endif
+
 #include "Pokitto_settings.h"
 #include <SDL2/SDL.h>
 

--- a/Pokitto/POKITTO_SIM/SimSound.cpp
+++ b/Pokitto/POKITTO_SIM/SimSound.cpp
@@ -103,7 +103,9 @@ void pokPlayStream() {
 
 void pokSoundIRQ() {
     #ifndef POK_SIM
+    #if POK_USE_PWM
     pwmout_t* obj = &audiopwm;
+    #endif
     #endif
     #if POK_STREAMING_MUSIC > 0
         #if POK_STREAMFREQ_HALVE

--- a/Pokitto/Pokitto_settings.h
+++ b/Pokitto/Pokitto_settings.h
@@ -531,7 +531,7 @@
 
 
 #define POK_BACKLIGHT_PIN P2_2
-#define POK_BACKLIGHT_INITIALVALUE 0.3f
+#define POK_BACKLIGHT_INITIALVALUE 30 // 30%
 
 #define POK_BATTERY_PIN1 P0_22 // read battery level through these pins
 #define POK_BATTERY_PIN2 P0_23

--- a/Pokitto/Pokitto_settings.h
+++ b/Pokitto/Pokitto_settings.h
@@ -316,6 +316,16 @@
 #endif
 #endif // POK_TILEDMODE
 
+
+#if PROJ_SCREENMODE == 1
+    #define POK_SCREENMODE MODE_HI_4COLOR
+    #undef POK_COLORDEPTH
+    #define POK_COLORDEPTH 2
+    #define LCDWIDTH POK_LCD_W
+    #define LCDHEIGHT POK_LCD_H
+#endif
+
+
 #if PROJ_MODE13 > 0 || PROJ_SCREENMODE == 13
     #undef POK_SCREENMODE //get rid of warnings
     #undef POK_COLORDEPTH

--- a/Pokitto/Pokitto_settings.h
+++ b/Pokitto/Pokitto_settings.h
@@ -318,6 +318,7 @@
 
 
 #if PROJ_SCREENMODE == 1
+    #undef POK_SCREENMODE //get rid of warnings
     #define POK_SCREENMODE MODE_HI_4COLOR
     #undef POK_COLORDEPTH
     #define POK_COLORDEPTH 2

--- a/Pokitto/libpff/connect.h
+++ b/Pokitto/libpff/connect.h
@@ -7,7 +7,7 @@ namespace PFFS {
 #define CONNECT_MISO    P0_8 //p6
 #define CONNECT_SCK     P0_6 //p7
 #define CONNECT_CS      P0_7 //p13
-#define SPI_FREQ        20000000 // was 400000
+#define SPI_FREQ        24000000 // was 400000
 
 } // namespace PFFS
 

--- a/Pokitto/mbed-pokitto/targets/hal/TARGET_NXP/TARGET_LPC11U6X/pwmout_api.c
+++ b/Pokitto/mbed-pokitto/targets/hal/TARGET_NXP/TARGET_LPC11U6X/pwmout_api.c
@@ -182,11 +182,11 @@ void pwmout_period_us(pwmout_t* obj, int us) {
     LPC_SCT0_Type* pwm = obj->pwm;
     uint32_t t_off = pwm->MATCHREL0 + 1;
     uint32_t t_on  = pwm->MATCHREL1 + 1;
-    float v = (float)t_on/(float)t_off;
+    
     //obj->pwm->MATCHREL0 = (uint32_t)us;
     //obj->pwm->MATCHREL1 = (uint32_t)((float)us * (float)v);
-    uint32_t period_ticks = (uint32_t)(((uint64_t)SystemCoreClock * (uint64_t)us) / (uint64_t)1000000);
-    uint32_t pulsewidth_ticks = period_ticks * v;
+    uint32_t period_ticks = (SystemCoreClock / 1000000) * us;
+    uint32_t pulsewidth_ticks = (period_ticks * t_on) / t_off;
     pwm->MATCHREL0 = period_ticks - 1;
     if (pulsewidth_ticks > 0) {
         pwm->MATCHREL1 = pulsewidth_ticks - 1;

--- a/Pokitto/mbed-pokitto/targets/hal/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/Pokitto/mbed-pokitto/targets/hal/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -139,7 +139,7 @@ void spi_frequency(spi_t *obj, int hz) {
 
         // calculate the divider
         #ifndef MINILOADHIGH
-        int divider = floor(((float)prescale_hz / (float)hz) + 0.5f);
+        uint32_t divider = ((prescale_hz + (prescale_hz >> 1)) / hz);
         #else
         //avoid using float to minimize binary size
         uint32_t divider = 1;

--- a/Pokitto/mbed-pokitto/targets/hal/TARGET_NXP/TARGET_LPC11U6X/us_ticker.c
+++ b/Pokitto/mbed-pokitto/targets/hal/TARGET_NXP/TARGET_LPC11U6X/us_ticker.c
@@ -20,7 +20,7 @@
 #define US_TICKER_TIMER          ((LPC_CT32B0_Type *)LPC_CT32B1_BASE)
 #define US_TICKER_TIMER_IRQn     CT32B1_IRQn
 
-int us_ticker_inited = 0;
+uint8_t us_ticker_inited = 0;
 
 void us_ticker_init(void) {
     if (us_ticker_inited) return;


### PR DESCRIPTION
- Remove float to save flash space.
- Remove unused variables to save ram.
- Fix Screen mode 1.
- Remove all the warning.
- Fix currentFile buffer overflow.
- Buttons in polling mode, dac write and backlight are not using mbed any more. 

Galaxy Fighter goes from:
Flash: 93%
RAM: 82.5%
to:
Flash: 88.4%
RAM: 78.9%
