### PR TITLE
Cleanup, C++17, TASMode, Bugfixes

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoCore.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoCore.cpp
@@ -971,7 +971,7 @@ bool Core::update(bool useDirectMode, uint8_t updRectX, uint8_t updRectY, uint8_
 			updatePopup();
 			displayBattery();
         #endif
-            display.update(useDirectMode, updRectX, updRectY, updRectW, updRectH); //send the buffer to the screen
+            display.update(useDirectMode); //send the buffer to the screen
 
             frameEndMicros = 1; //jonne
 

--- a/Pokitto/POKITTO_CORE/PokittoCore.h
+++ b/Pokitto/POKITTO_CORE/PokittoCore.h
@@ -65,13 +65,6 @@
 #include "PokittoSound.h"
 #include "PokittoFakeavr.h"
 
-#if ((POK_SCREENMODE==MODE_FAST_16COLOR) || (POK_SCREENMODE==MODE15) || (POK_SCREENMODE==MODE_HI_16COLOR))
-    #define PALETTE_SIZE 16
-#else
-    #define PALETTE_SIZE 256
-#endif
-
-
 #define PI 3.141592741f
 
 // For GB compatibility

--- a/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
@@ -63,24 +63,17 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 */
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <cstddef>
+#include <algorithm>
 
 #include "PokittoDisplay.h"
 #include "Pokitto_settings.h"
 #include "GBcompatibility.h"
 #include "PokittoCore.h"
 #include "PokittoSound.h"
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-#include <cstddef>
-#ifdef DISABLEAVRMIN
-#include <algorithm>
-using std::min;
-using std::max;
-#else // DISABLEAVRMIN
-#define max(a,b) ((a)>(b)?(a):(b))
-#define min(a,b) ((a)<(b)?(a):(b))
-#endif // DISABLEAVRMIN
 
 #ifndef POK_SIM
 #include "HWLCD.h"
@@ -90,31 +83,18 @@ using std::max;
 
 extern "C" void CheckStack();
 extern char _ebss[];  // In map file
-extern char _vStackTop[];  // In map file
+extern void _vStackTop(void);
 
-Pokitto::Core core;
-Pokitto::Sound _pdsound;
-
+using core = Pokitto::Core;
+using _pdsound = Pokitto::Sound;
 using namespace Pokitto;
 
 uint8_t* Display::m_scrbuf;
-
-#if (POK_SCREENMODE == MODE_TILED_1BIT)
-uint8_t* Display::m_tileset;
-uint8_t* Display::m_tilebuf;
-uint8_t* Display::m_tilecolorbuf;
-#endif
-
 uint8_t Display::m_mode;
 uint8_t Display::palOffset;
-
-#if (POK_SCREENMODE == MODE_HI_4COLOR)
-    SpriteInfo Display::m_sprites[SPRITE_COUNT];
-#endif
-
 uint8_t Display::fontSize=1;
-int16_t Display::cursorX,Display::cursorY;
-uint8_t Display::m_w,Display::m_h;
+int16_t Display::cursorX, Display::cursorY;
+uint8_t Display::m_w, Display::m_h;
 uint8_t Display::fontWidth, Display::fontHeight;
 bool Display::textWrap=true;
 
@@ -126,13 +106,6 @@ uint16_t Display::directcolor=0xFFFF;
 uint16_t Display::directbgcolor=0x0;
 bool Display::directtextrotated=false;
 
- #if (POK_COLORDEPTH==2)
-int16_t Display::clipX = 0;
-int16_t Display::clipY = 0;
-int16_t Display::clipW = LCDWIDTH;
-int16_t Display::clipH = LCDHEIGHT;
-#endif
-
 uint16_t* Display::paletteptr;
 uint16_t Display::palette[PALETTE_SIZE];
 const unsigned char* Display::font;
@@ -140,73 +113,12 @@ int8_t Display::adjustCharStep = 1;
 int8_t Display::adjustLineStep = 1;
 bool Display::fixedWidthFont = false, Display::flipFontVertical = false;
 
-/** drawing canvas **/
-//uint8_t* Display::canvas; // points to the active buffer. if null, draw direct to screen
-
 /** screenbuffer **/
-uint8_t Display::m_colordepth = POK_COLORDEPTH;
-#ifndef POK_TILEDMODE
-#if (POK_SCREENMODE == MODE_HI_MONOCHROME)
-    uint8_t Display::width = POK_LCD_W;
-    uint8_t Display::height = POK_LCD_H;
-    uint8_t Display::screenbuffer[((POK_LCD_H+1)*POK_LCD_W)*POK_COLORDEPTH/8]; // maximum resolution
-#elif (POK_SCREENMODE == MODE_HI_4COLOR)
-    uint8_t Display::width = POK_LCD_W;
-    uint8_t Display::height = POK_LCD_H;
-    uint8_t __attribute__((section (".bss"))) __attribute__ ((aligned)) Display::screenbuffer[((POK_LCD_H)*POK_LCD_W)/4]; // maximum resolution
-#elif (POK_SCREENMODE == MODE_FAST_16COLOR)
-    uint8_t Display::width = POK_LCD_W/2;
-    uint8_t Display::height = POK_LCD_H/2;
-    uint8_t Display::screenbuffer[(((POK_LCD_H/2)+1)*POK_LCD_W/2)*POK_COLORDEPTH/8]; // half resolution
-#elif (POK_SCREENMODE == MODE_HI_16COLOR)
-    uint8_t Display::width = POK_LCD_W;
-    uint8_t Display::height = POK_LCD_H;
-    uint8_t Display::screenbuffer[POK_LCD_H*POK_LCD_W/2]; // 4 bits per pixel
-#elif (POK_SCREENMODE == MODE_LAMENES)
-    uint8_t Display::width = 128;
-    uint8_t Display::height = 120;
-    uint8_t Display::screenbuffer[((121)*128)*POK_COLORDEPTH/8]; // half resolution
-#elif (POK_SCREENMODE == MODE_GAMEBOY)
-    uint8_t Display::width = 160;
-    uint8_t Display::height = 144;
-    uint8_t Display::screenbuffer[160*144/4];
-#elif (POK_SCREENMODE == MODE14)
-    uint8_t Display::width = 220;
-    uint8_t Display::height = 176;
-    uint8_t Display::screenbuffer[14520];
-#elif (POK_SCREENMODE == MODE13)
-    uint8_t Display::width = 110;
-    uint8_t Display::height = 88;
-    uint8_t Display::screenbuffer[110*88]; // 8bit 110x88
-#elif (POK_SCREENMODE == MIXMODE)
-    uint8_t Display::width = 110;
-    uint8_t Display::height = 88;
-    uint8_t Display::screenbuffer[110*88]; // 8bit 110x88 or 4bit 110x176
-    uint8_t Display::scanType[88]; // scanline bit depth indicator
-#elif (POK_SCREENMODE == MODE64)
-    uint8_t Display::width = 110;
-    uint8_t Display::height = 176;
-    uint8_t __attribute__ ((aligned)) Display::screenbuffer[110*176]; // 8bit 110x176
-#elif (POK_SCREENMODE == MODE15)
-    uint8_t Display::width = 220;
-    uint8_t Display::height = 176;
-    uint8_t __attribute__ ((aligned)) Display::screenbuffer[0x4BA0];
-#else
-    uint8_t Display::width = 84;
-    uint8_t Display::height = 48;
-    uint8_t Display::screenbuffer[128*64]; // not needed because Gamebuino and Arduboy have their own buffer
-#endif
-#else //Tiledmode
-#if (POK_SCREENMODE == MODE_TILED_1BIT)
-    uint8_t Display::width = POK_LCD_W;
-    uint8_t Display::height = POK_LCD_H;
-    uint8_t Display::screenbuffer[0];
-#else
-    uint8_t Display::width = POK_LCD_W;
-    uint8_t Display::height = POK_LCD_H;
-    uint8_t Display::screenbuffer[0];
-#endif
-#endif //tiledmode
+uint8_t Display::m_colordepth = PROJ_COLORDEPTH;
+uint8_t Display::width = LCDWIDTH;
+uint8_t Display::height = LCDHEIGHT;
+
+uint8_t __attribute__((section (".bss"))) __attribute__ ((aligned)) Display::screenbuffer[POK_SCREENBUFFERSIZE]; // maximum resolution
 
 // RLE decoding
 #define RLE_ESC_EOL 0
@@ -222,29 +134,19 @@ Display::Display() {
     setFont(DEFAULT_FONT);
     invisiblecolor=17;
     bgcolor=0;
-    if (POK_COLORDEPTH) m_colordepth = POK_COLORDEPTH;
+    if (PROJ_COLORDEPTH) m_colordepth = PROJ_COLORDEPTH;
     else m_colordepth = 4;
     #if POK_GAMEBUINO_SUPPORT
     setColorDepth(1);
     #endif // POK_GAMEBUINO_SUPPORT
-
-    // Reset sprites
-#if POK_SCREENMODE == MODE_TILED_1BIT
-    m_tilecolorbuf = NULL;
-#endif
-
-#if (POK_SCREENMODE == MODE_HI_4COLOR)
-    for (uint8_t s = 0; s < SPRITE_COUNT; s++)
-        m_sprites[s].bitmapData = NULL;
-#endif
 }
 
 uint16_t Display::getWidth() {
     return width;
 }
 
-uint8_t Display::getNumberOfColors() {
-    return 1<<POK_COLORDEPTH;
+uint32_t Display::getNumberOfColors() {
+    return 1<<PROJ_COLORDEPTH;
 }
 
 uint16_t Display::getHeight() {
@@ -256,7 +158,7 @@ uint8_t Display::getColorDepth() {
 }
 
 void Display::setColorDepth(uint8_t v) {
-    if (v > POK_COLORDEPTH) v=POK_COLORDEPTH;
+    if (v > PROJ_COLORDEPTH) v=PROJ_COLORDEPTH;
     m_colordepth = v;
 }
 
@@ -302,64 +204,20 @@ void Display::setCursor(int16_t x,int16_t y) {
  * @param updRectW The update rect.
  * @param updRectH The update rect.
  */
-void Display::update(bool useDirectDrawMode, uint8_t updRectX, uint8_t updRectY, uint8_t updRectW, uint8_t updRectH) {
+void Display::update(bool useDirectDrawMode) {
+    
+    if (!useDirectDrawMode)
+        lcdRefresh(m_scrbuf, useDirectDrawMode);
 
-    #if POK_SCREENMODE == MODE_HI_4COLOR
-    // If there is one or more sprites, use sprite enabled drawing.
-    if (m_sprites[0].bitmapData != NULL)
-        lcdRefreshMode1Spr(m_scrbuf, updRectX, updRectY, updRectW, updRectH, paletteptr, m_sprites, useDirectDrawMode);
-    else if (!useDirectDrawMode)
-        lcdRefreshMode1(m_scrbuf, updRectX, updRectY, updRectW, updRectH, paletteptr);
+    /** draw FPS if visible **/
+    #ifdef PROJ_SHOW_FPS_COUNTER
+    printFPS();
     #endif
 
-    // For the screen modes that do not support sprites, return if the direct draw mode is used.
-    if (! useDirectDrawMode) {
-		#if POK_SCREENMODE == MODE13
-		lcdRefreshMode13(m_scrbuf, paletteptr, palOffset);
-		#endif
-
-		#if POK_SCREENMODE == MIXMODE
-		lcdRefreshMixMode(m_scrbuf, paletteptr, scanType);
-		#endif
-
-		#if POK_SCREENMODE == MODE64
-		lcdRefreshMode64(m_scrbuf, paletteptr);
-		#endif
-
-        #if POK_SCREENMODE == MODE_GAMEBOY
-        lcdRefreshModeGBC(m_scrbuf, paletteptr);
-        #endif
-
-        #if POK_SCREENMODE == MODE_HI_16COLOR
-        lcdRefreshMode3(m_scrbuf, paletteptr);
-        #endif
-
-        #if POK_SCREENMODE == MODE_FAST_16COLOR
-        lcdRefreshMode2(m_scrbuf, paletteptr);
-        #endif
-
-        #if POK_SCREENMODE == MODE_GAMEBUINO_16COLOR
-        lcdRefreshGB(m_scrbuf, paletteptr);
-        #endif
-
-        #if POK_SCREENMODE == MODE_ARDUBOY_16COLOR
-        lcdRefreshAB(m_scrbuf, paletteptr);
-        #endif
-
-        #if POK_SCREENMODE == MODE14
-        lcdRefreshMode14(m_scrbuf, paletteptr);
-        #endif
-
-        #if POK_SCREENMODE == MODE15
-        lcdRefreshMode15(paletteptr, m_scrbuf);
-        #endif
-
-        #if POK_SCREENMODE == MODE_TILED_1BIT
-        lcdRefreshT1(m_tilebuf, m_tilecolorbuf, m_tileset, paletteptr);
-        #endif
-    }
-
-    if (!persistence) clear();
+    #ifndef PERSISTENCE
+    if (!persistence)
+        clear();
+    #endif
 
     /** draw volume bar if visible **/
     #if POK_SHOW_VOLUME > 0
@@ -368,45 +226,41 @@ void Display::update(bool useDirectDrawMode, uint8_t updRectX, uint8_t updRectY,
             core.volbar_visible--;
     }
     #endif // POK_SHOW_VOLUME
+}
 
-    /** draw FPS if visible **/
-    #ifdef PROJ_SHOW_FPS_COUNTER
+void Display::printFPS(){
+    if(!core.fps_counter_updated)
+        return;
+    core.fps_counter_updated = false;
 
-    if(core.fps_counter_updated) {
+    // Store current state
+    bool temp = isDirectPrintingEnabled();
+    uint16_t oldcol = directcolor;
+    uint16_t oldinvisiblecolor = invisiblecolor;
+    uint16_t oldbgcol = directbgcolor;
+    bool olddirecttextrotated = directtextrotated;
+    int8_t oldadjustCharStep = adjustCharStep;
+    const unsigned char * oldFont = font;
 
-        // Store current state
-        bool temp = isDirectPrintingEnabled();
-        uint16_t oldcol = directcolor;
-        uint16_t oldinvisiblecolor = invisiblecolor;
-        uint16_t oldbgcol = directbgcolor;
-        bool olddirecttextrotated = directtextrotated;
-        int8_t oldadjustCharStep = adjustCharStep;
-        const unsigned char * oldFont = font;
+    // Print FPS
+    directcolor = COLOR_WHITE;
+    invisiblecolor = COLOR_BLACK;
+    directbgcolor = 0x0001; // Cannot be black as that is transparent color
+    directtextrotated = false;
+    adjustCharStep = 0;
+    setFont(fontC64);
+    enableDirectPrinting(true);
+    print(0, 0, "FPS:");
+    print((int)core.fps_counter);
 
-        // Print FPS
-        char str[16];
-        sprintf(str,"FPS:%d ", (int)core.fps_counter);
-        directcolor = COLOR_WHITE;
-        invisiblecolor = COLOR_BLACK;
-        directbgcolor = 0x0001; // Cannot be black as that is transparent color
-        directtextrotated = false;
-        adjustCharStep = 0;
-        setFont(fontC64);
-        enableDirectPrinting(true);
-        print(0,0, str);
-
-        // Restore state
-        enableDirectPrinting(temp);
-        directcolor = oldcol;
-        invisiblecolor =  oldinvisiblecolor;
-        directbgcolor = oldbgcol;
-        directtextrotated = olddirecttextrotated;
-        adjustCharStep = oldadjustCharStep;
-        setFont(oldFont);
-
-        core.fps_counter_updated = false;
-    }
-    #endif
+    // Restore state
+    enableDirectPrinting(temp);
+    directcolor = oldcol;
+    invisiblecolor =  oldinvisiblecolor;
+    directbgcolor = oldbgcol;
+    directtextrotated = olddirecttextrotated;
+    adjustCharStep = oldadjustCharStep;
+    setFont(oldFont);
 }
 
 void Display::directBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t depth, uint8_t scale) {
@@ -610,27 +464,17 @@ void Display::clear() {
 
     uint8_t c=0;
     c = bgcolor & (PALETTE_SIZE-1) ; //don't let palette go out of bounds
-    if (m_colordepth==1 && bgcolor) c=0xFF; // bgcolor !=0, set all pixels
-    else if (m_colordepth==2) {
+    if (m_colordepth==1 && bgcolor) {
+        c = 0xFF; // bgcolor !=0, set all pixels
+    } else if (m_colordepth==2) {
         c = bgcolor & 0x3;
         c = c | (c << 2);
         c = c | (c << 4);
-    } else if (m_colordepth==3){
-        uint16_t j = POK_BITFRAME;
-        if (bgcolor & 0x1) memset((void*)m_scrbuf,0xFF,j);// R
-        else memset((void*)m_scrbuf,0x00,j);// R
-        if ((bgcolor>>1) & 0x1) memset((char*)m_scrbuf+POK_BITFRAME,0xFF,j);// G
-        else memset((char*)m_scrbuf+POK_BITFRAME,0x00,j);// G
-        if ((bgcolor>>2) & 0x1) memset((char*)m_scrbuf+POK_BITFRAME*2,0xFF,j);// B
-        else memset((char*)m_scrbuf+POK_BITFRAME*2,0x00,j);// B
-        setCursor(0,0);
-        return;
     } else if (m_colordepth==4) {
         c = (c & 0x0F) | (c << 4);
     }
-    uint16_t j = sizeof(screenbuffer);
-    memset((void*)m_scrbuf,c,j);
 
+    memset((void*)m_scrbuf, c, POK_SCREENBUFFERSIZE);
     setCursor(0,0);
 
 }
@@ -645,15 +489,15 @@ void Display::scroll(int16_t pixelrows) {
     oc = color;
     color = bgcolor;
     if (pixelrows>0) {
-    for (uint16_t y=0;y<height-pixelrows;y++) {
+        for (uint16_t y=0;y<height-pixelrows;y++) {
             for (uint16_t x=0;x<(width/8)*m_colordepth;x++) screenbuffer[index++]=screenbuffer[index2++];
-    }
-    fillRect(0,cursorY,width,height);
+        }
+        fillRect(0,cursorY,width,height);
     } else {
-    for (uint16_t y=pixelrows;y<height;y++) {
+        for (uint16_t y=pixelrows;y<height;y++) {
             for (uint16_t x=0;x<(width*m_colordepth)/8;x++) screenbuffer[index2++]=screenbuffer[index++];
-    }
-    fillRect(0,0,width,pixelrows);
+        }
+        fillRect(0,0,width,pixelrows);
     }
     color=oc;
 }
@@ -668,7 +512,7 @@ void Display::fillScreen(uint16_t c) {
     } else if (m_colordepth==4){
         c = (c & 0x0F) | (c << 4);
     }
-    memset((void*)m_scrbuf,c,sizeof(screenbuffer));
+    memset((void*)m_scrbuf, c, POK_SCREENBUFFERSIZE);
 }
 
 void Display::setDefaultPalette() {
@@ -680,12 +524,12 @@ void Display::setDefaultPalette() {
 }
 
 void Display::setColor(uint8_t c) {
-    color = c & ((1<<POK_COLORDEPTH)-1); // cut out colors that go above palette limit
+    color = c & ((1<<PROJ_COLORDEPTH)-1); // cut out colors that go above palette limit
 }
 
 void Display::setColor(uint8_t c,uint8_t bgc){
-    color = c & ((1<<POK_COLORDEPTH)-1); // cut out colors that go above palette limit
-    bgcolor = bgc & ((1<<POK_COLORDEPTH)-1); // cut out colors that go above palette limit
+    color = c & ((1<<PROJ_COLORDEPTH)-1); // cut out colors that go above palette limit
+    bgcolor = bgc & ((1<<PROJ_COLORDEPTH)-1); // cut out colors that go above palette limit
 }
 
 void Display::setInvisibleColor(uint16_t c){
@@ -704,42 +548,17 @@ uint16_t Display::getInvisibleColor() {
     return invisiblecolor;
 }
 
-#if (POK_COLORDEPTH==2)
-void Display::setClipRect(int16_t x, int16_t y, int16_t w, int16_t h) {
-    clipX = x; clipY = y; clipW = w; clipH = h;
-}
-#endif
-
 void Display::drawPixelNOP(int16_t x,int16_t y, uint8_t col) {
 }
 
 void Display::drawPixelRaw(int16_t x,int16_t y, uint8_t col) {
-    #if POK_COLORDEPTH == 8
+#if PROJ_SCREENMODE != TASMODE
+    if( PROJ_COLORDEPTH == 8 ){
+
         m_scrbuf[x+width*y] = col;
-    #endif
 
-    #if POK_GAMEBUINO_SUPPORT >0
+    } else if( PROJ_COLORDEPTH == 2 ) {
 
-	uint8_t c = col;
-	uint8_t ct = col;
-
-    uint16_t bitptr=0;
-    for (uint8_t cbit=0;cbit<POK_COLORDEPTH;cbit++) {
-	c = ct & 1; // take the lowest bit of the color index number
-	if(c == 0){ //white - or actually "Clear bit"
-		m_scrbuf[x + (y / 8) * LCDWIDTH + bitptr] &= ~_BV(y % 8);
-	} else { //black - or actually "Set bit"
-		m_scrbuf[x + (y / 8) * LCDWIDTH + bitptr] |= _BV(y % 8);
-	}
-	ct >>=1; // shift to get next bit
-	bitptr += POK_BITFRAME; // move one screen worth of buffer forward to get to the next color bit
-    } // POK_COLOURDEPTH
-
-    #else
-    #if POK_COLORDEPTH == 1
-        if (col) {m_scrbuf[(y >> 3) * width + x] |= (0x80 >> (y & 7)); return;}
-        m_scrbuf[(y >> 3) * width + x] &= ~(0x80 >> (y & 7));
-    #elif POK_COLORDEPTH == 2
         if (col) {
                 col &= 3;
         }
@@ -751,29 +570,17 @@ void Display::drawPixelRaw(int16_t x,int16_t y, uint8_t col) {
         else if (column==1) pixel = (pixel&0xCF)|(col<<4); // bits 4-5
         else pixel = (pixel&0x3F)|(col<<6); // bits 6-7
         m_scrbuf[i] = pixel;
-    #elif POK_COLORDEPTH == 3
-    uint8_t c = col;
-	uint8_t ct = col;
 
-    uint16_t bitptr=0;
-    for (uint8_t cbit=0;cbit<POK_COLORDEPTH;cbit++) {
-	c = ct & 1; // take the lowest bit of the color index number
-	if(c == 0){ //white - or actually "Clear bit"
-		m_scrbuf[x + (y / 8) * LCDWIDTH + bitptr] &= ~_BV(y % 8);
-	} else { //black - or actually "Set bit"
-		m_scrbuf[x + (y / 8) * LCDWIDTH + bitptr] |= _BV(y % 8);
-	}
-	ct >>=1; // shift to get next bit
-	bitptr += POK_BITFRAME; // move one screen worth of buffer forward to get to the next color bit
-    } // POK_COLOURDEPTH
-    #elif POK_COLORDEPTH == 4
-    uint16_t i = y*(width>>1) + (x>>1);
-    uint8_t pixel = m_scrbuf[i];
-    if (x&1) pixel = (pixel&0xF0)|(col);
-    else pixel = (pixel&0x0F) | (col<<4);
-    m_scrbuf[i] = pixel;
-    #endif // POK_COLORDEPTH
-    #endif // POK_GAMEBUINO_SUPPORT
+    } else if( PROJ_COLORDEPTH == 4 ) {
+
+        uint16_t i = y*(width>>1) + (x>>1);
+        uint8_t pixel = m_scrbuf[i];
+        if (x&1) pixel = (pixel&0xF0)|(col);
+        else pixel = (pixel&0x0F) | (col<<4);
+        m_scrbuf[i] = pixel;
+
+    }
+#endif
 }
 
 void Display::drawPixel(int16_t x,int16_t y, uint8_t col) {
@@ -789,23 +596,14 @@ void Display::drawPixel(int16_t x,int16_t y) {
 }
 
 uint8_t Display::getPixel(int16_t x,int16_t y) {
-    if ((uint16_t)x >= width || (uint16_t)y >= height) return 0;
-    #if POK_COLORDEPTH == 8
-    uint16_t i = y*width+x;
-    return m_scrbuf[i];
-    #endif // POK_COLORDEPTH
+    if ((uint16_t)x >= width || (uint16_t)y >= height)
+        return 0;
 
-    #if POK_GAMEBUINO_SUPPORT
-    uint8_t color=0; //jonne
-	for (uint8_t cbit=0; cbit<POK_COLORDEPTH;cbit++) {
-    	color |= (m_scrbuf[x + (y / 8) * LCDWIDTH+POK_BITFRAME*cbit] >> (y % 8)) & 0x1 ; //jonne - added +504*cbit
-	}
-	return color;
-    #else
-    /** not gamebuino */
-    #if POK_COLORDEPTH == 1
-        return (m_scrbuf[(y >> 3) * width + x] & (0x80 >> (y & 7))) ? 1:0;
-    #elif POK_COLORDEPTH == 2
+    #if PROJ_COLORDEPTH == 8
+    return m_scrbuf[y*width+x];
+    #endif // PROJ_COLORDEPTH
+        
+    #if PROJ_COLORDEPTH == 2
         uint16_t i = y*(width>>2) + (x>>2);
         uint8_t pixel = m_scrbuf[i];
         uint8_t column = x&0x03;
@@ -813,14 +611,16 @@ uint8_t Display::getPixel(int16_t x,int16_t y) {
         else if (column==1) return (pixel & 0x0C)>>2; // bits 2-3
         else if (column==2) return (pixel & 0x30)>>4; // bits 4-5
         else return pixel>>6;; // bits 6-7
-    #elif POK_COLORDEPTH == 3
-    #elif POK_COLORDEPTH == 4
+    #endif
+
+    #if PROJ_COLORDEPTH == 4
     uint16_t i = y*(width>>1) + (x>>1);
     uint8_t pixel = m_scrbuf[i];
     if (x&1) return pixel & 0x0F;
     else return pixel>>4;
-    #endif // POK_COLORDEPTH
-    #endif // POK_GAMEBUINO_SUPPORT
+    #endif // PROJ_COLORDEPTH
+
+    return 0;
 }
 
 void Display::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1) {
@@ -1266,26 +1066,13 @@ void Display::setFont(const unsigned char * f) {
 	fontHeight = *(font + 1)+1;
 }
 
+#if PROJ_SCREENMODE != TASMODE
 void Display::drawMonoBitmap(int16_t x, int16_t y, const uint8_t* bitmap, uint8_t index) {
     uint8_t w = *bitmap;
 	uint8_t h = *(bitmap + 1);
 	uint8_t xtra=0;
 	if (w&0x7) xtra=1;
 	bitmap = bitmap + 3 + index * h * ((w>>3)+xtra); //add an offset to the pointer (fonts !)
-    #if POK_GAMEBUINO_SUPPORT > 0
-    int8_t i, j, byteNum, bitNum, byteWidth = (w + 7) >> 3;
-    for (i = 0; i < w; i++) {
-        byteNum = i / 8;
-        bitNum = i % 8;
-        for (j = 0; j < h; j++) {
-            uint8_t source = *(bitmap + j * byteWidth + byteNum);
-            if (source & (0x80 >> bitNum)) {
-                drawPixel(x + i, y + j);
-            }
-        }
-    }
-    #else
-    /** not gamebuino */
     int8_t scrx,scry;
     uint8_t* scrptr = m_scrbuf + (y*(width>>1) + (x>>1));
     int8_t bitptr;
@@ -1322,27 +1109,16 @@ void Display::drawMonoBitmap(int16_t x, int16_t y, const uint8_t* bitmap, uint8_
             // increment the y jump in the scrptr
             scrptr = scrptr + ((width - w)>>1);
     }
-    #endif // POK_GAMEBUINO_SUPPORT
 }
 
 
 void Display::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frameIndex)
 {
 	using std::size_t;
-
-	#if defined(__cpp_constexpr)
-	#define CONSTEXPR constexpr
-	#else
-	#define CONSTEXPR const
-	#endif
-
-	CONSTEXPR size_t widthIndex = 0;
-	CONSTEXPR size_t heightIndex = 1;
-	CONSTEXPR size_t dataIndex = 2;
-	CONSTEXPR size_t bitsPerByte = 8;
-
-	#undef CONSTEXPR
-
+	constexpr size_t widthIndex = 0;
+	constexpr size_t heightIndex = 1;
+	constexpr size_t dataIndex = 2;
+	constexpr size_t bitsPerByte = 8;
 	const size_t width = bitmap[widthIndex];
 	const size_t height = bitmap[heightIndex];
 	const size_t frameSize = ((width * height) / (bitsPerByte / Display::m_colordepth));
@@ -1354,113 +1130,32 @@ void Display::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t f
 void Display::drawBitmap(int16_t x, int16_t y, const uint8_t* bitmap)
 {
     int16_t w = *bitmap;
-	int16_t h = *(bitmap + 1);
-    bitmap = bitmap + 2; //add an offset to the pointer to start after the width and height
+    int16_t h = *(bitmap + 1);
+    //add an offset to the pointer to start after the width and height
+    bitmap = bitmap + 2; 
     drawBitmapData(x, y, w, h, bitmap);
 }
 
-void Display::drawBitmapData(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t* bitmap) {
-    /** visibility check */
-    if (y<-h || y>height) return; //invisible
-    if (x<-w || x>width) return;  //invisible
-    /** 1 bpp mode */
-    if (m_colordepth<2) {
-    int16_t i, j, byteNum, bitNum, byteWidth = (w + 7) >> 3;
+void Display::drawBitmapData2BPP(int x, int y, int w, int h, const uint8_t* bitmap){
+    int16_t i, j, byteNum, bitNum, byteWidth = w >> 2;
     for (i = 0; i < w; i++) {
-        byteNum = i / 8;
-        bitNum = i % 8;
+        byteNum = i / 4;
+        bitNum = (i % 4)<<1;
         for (j = 0; j < h; j++) {
-            uint8_t source = *(bitmap + j * byteWidth + byteNum);
-            if (source & (0x80 >> bitNum)) {
+            uint8_t source = *(bitmap + (j * byteWidth) + byteNum);
+            uint8_t output = (source & (0xC0 >> bitNum));
+            output >>= (6-bitNum);
+            if (output != Display::invisiblecolor) {
+                setColor(output);
                 drawPixel(x + i, y + j);
             }
         }
     }
+}
 
-    return;
-    }
-    /** 2 bpp mode */
-    else if (m_colordepth==2) {
-    #if (POK_COLORDEPTH == 2)
-        if(clipH > 0) {
-
-            // Clip
-            int16_t x1 = max(x, clipX);
-            int16_t x2 = min(x + w, clipX + clipW);
-            int16_t bmupdateX = x1 - x;
-            int16_t bmupdateX2 = x2 - x;
-            int16_t y1 = max(y, clipY);
-            int16_t y2 = min(y + h, clipY + clipH);
-            int16_t bmupdateY = y1 - y;
-            int16_t bmupdateY2 = y2 - y;
-
-            int16_t i, j, byteNum, bitNum, byteWidth = w >> 2;
-            for (i = bmupdateX; i < bmupdateX2; i++) {
-                byteNum = i / 4;
-                bitNum = (i % 4)<<1;
-                for (j = bmupdateY; j < bmupdateY2; j++) {
-                    uint8_t source = *(bitmap + (j * byteWidth) + byteNum);
-                    uint8_t output = (source & (0xC0 >> bitNum));
-                    output >>= (6-bitNum);
-                    if (output != invisiblecolor) {
-                        setColor(output);
-                        drawPixel(x + i, y + j);
-                    }
-                }
-            }
-        }
-        else
-    #endif
-        {
-            int16_t i, j, byteNum, bitNum, byteWidth = w >> 2;
-            for (i = 0; i < w; i++) {
-                byteNum = i / 4;
-                bitNum = (i % 4)<<1;
-                for (j = 0; j < h; j++) {
-                    uint8_t source = *(bitmap + (j * byteWidth) + byteNum);
-                    uint8_t output = (source & (0xC0 >> bitNum));
-                    output >>= (6-bitNum);
-                    if (output != invisiblecolor) {
-                        setColor(output);
-                        drawPixel(x + i, y + j);
-                    }
-                }
-            }
-        }
-        return;
-    }
-
-    /** 3 bpp mode */
-    else if (m_colordepth==3) {
-        int16_t i, j, byteNum, byteWidth = (w + 7) >> 3;
-        int16_t bitFrame = w * h / 8;
-        for (i = 0; i < w; i++) {
-        byteNum = i / 8;
-        //bitNum = i % 8;
-
-        uint8_t bitcount=0;
-        for (j = 0; j <= h/8; j++) {
-            uint8_t r_val = *(bitmap + j * byteWidth + byteNum);
-            uint8_t g_val = *(bitmap + bitFrame + j * byteWidth + byteNum);
-            uint8_t b_val = *(bitmap + (bitFrame<<1) + j * byteWidth + byteNum);
-            for (bitcount=0; bitcount<8; bitcount++) {
-                uint8_t col = (r_val&0x1) | ((g_val&0x1)<<1) | ((b_val&0x1)<<2);
-                r_val >>= 1; g_val >>= 1; b_val >>= 1;
-                drawPixel(x + i, y + j+bitcount,col);
-            }
-            }
-        }
-
-    return;
-    }
-
-
-    /** 4bpp fast version */
-    else if (m_colordepth==4) {
-
-    /** 4bpp fast version */
-	int16_t scrx,scry,xjump,scrxjump;
-	int16_t xclip;
+void Display::drawBitmapData4BPP(int x, int y, int w, int h, const uint8_t* bitmap){
+    int16_t scrx,scry,xjump,scrxjump;
+    int16_t xclip;
     xclip=xjump=scrxjump=0;
     /** y clipping */
     if (y<0) { h+=y; bitmap -= y*(w>>1); y=0;}
@@ -1468,118 +1163,133 @@ void Display::drawBitmapData(int16_t x, int16_t y, int16_t w, int16_t h, const u
     /** x clipping */
     if (x<0) { xclip=(x&1)<<1; w+=x; xjump = ((-x)>>1); bitmap += xjump; x=0;}
     else if (x+w>width) {
-            xclip = (x&1)<<1;
-            scrxjump = x&1;
-            xjump=((x+w-width)>>1)+scrxjump;
-            w = width-x;}
+        xclip = (x&1)<<1;
+        scrxjump = x&1;
+        xjump=((x+w-width)>>1)+scrxjump;
+        w = width-x;}
 
     uint8_t* scrptr = m_scrbuf + (y*(width>>1) + (x>>1));
     /** ONLY 4-bit mode for time being **/
     for (scry = y; scry < y+h; scry+=1) {
-            if (scry>=height) return;
-            if ((x&1)==0) { /** EVEN pixel starting line, very simple, just copypaste **/
-                for (scrx = x; scrx < w+x-xclip; scrx+=2) {
-                    uint8_t sourcepixel = *bitmap;
-                    if (xclip) {
-                            sourcepixel <<=4;
-                            sourcepixel |= ((*(bitmap+1))>>4);
-                    }
-                    uint8_t targetpixel = *scrptr;
-                    if ((sourcepixel>>4) != invisiblecolor ) targetpixel = (targetpixel&0x0F) | (sourcepixel & 0xF0);
-                    if ((sourcepixel&0x0F) != invisiblecolor) targetpixel = (targetpixel & 0xF0) | (sourcepixel & 0x0F);
-                    *scrptr = targetpixel;
-                    bitmap++;
-                    scrptr++;
-                }
-                if (xclip){
-                    if (w&1) {
-                        /**last pixel is odd pixel due to clipping & odd width*/
-                        uint8_t sourcepixel = *bitmap;
-                        if ((sourcepixel&0x0F) != invisiblecolor) {
-                            sourcepixel <<=4;
-                            volatile uint8_t targetpixel = *scrptr;// & 0x0F;
-                            targetpixel &= 0xF; //clear upper nibble
-                            targetpixel |= sourcepixel; //now OR it
-                            *scrptr = targetpixel;
-                        }
-                        //scrptr++;
-                    }
-                    bitmap++;
-                    scrptr++;
-                }
-                bitmap += xjump; // needed if x<0 clipping occurs
-            } else { /** ODD pixel starting line **/
-                uint8_t sourcepixel;
-                uint8_t targetpixel;
-                for (scrx = x; scrx < w+x-xclip; scrx+=2) {
-                    sourcepixel = *bitmap;
-                    targetpixel = *scrptr;
-                    // store higher nibble of source pixel in lower nibble of target
-                    if((sourcepixel>>4)!=invisiblecolor) targetpixel = (targetpixel & 0xF0) | (sourcepixel >> 4 );
-                    *scrptr = targetpixel;
-                    scrptr++;
-                    targetpixel = *scrptr;
-                    // store lower nibble of source pixel in higher nibble of target
-                    if((sourcepixel&0x0F)!=invisiblecolor) targetpixel = (targetpixel & 0x0F) | (sourcepixel << 4);
-                    *scrptr = targetpixel;
-                    bitmap++;
-                }
+        if (scry>=height) return;
+        if ((x&1)==0) { /** EVEN pixel starting line, very simple, just copypaste **/
+            for (scrx = x; scrx < w+x-xclip; scrx+=2) {
+                uint8_t sourcepixel = *bitmap;
                 if (xclip) {
-                    // last line, store higher nibble of last source pixel in lower nibble of last address
-                    targetpixel = *scrptr;
-                    sourcepixel = *bitmap >> 4;
-                    if(sourcepixel!=invisiblecolor) targetpixel = (targetpixel & 0xF0) | sourcepixel;
-                    *scrptr = targetpixel;
+                    sourcepixel <<=4;
+                    sourcepixel |= ((*(bitmap+1))>>4);
                 }
-                bitmap+=xjump;
+                uint8_t targetpixel = *scrptr;
+                if ((sourcepixel>>4) != Display::invisiblecolor ) targetpixel = (targetpixel&0x0F) | (sourcepixel & 0xF0);
+                if ((sourcepixel&0x0F) != Display::invisiblecolor) targetpixel = (targetpixel & 0xF0) | (sourcepixel & 0x0F);
+                *scrptr = targetpixel;
+                bitmap++;
+                scrptr++;
             }
-            // increment the y jump in the scrptr
-            scrptr = scrptr + ((width - w)>>1)+scrxjump;
+            if (xclip){
+                if (w&1) {
+                    /**last pixel is odd pixel due to clipping & odd width*/
+                    uint8_t sourcepixel = *bitmap;
+                    if ((sourcepixel&0x0F) != Display::invisiblecolor) {
+                        sourcepixel <<=4;
+                        volatile uint8_t targetpixel = *scrptr;// & 0x0F;
+                        targetpixel &= 0xF; //clear upper nibble
+                        targetpixel |= sourcepixel; //now OR it
+                        *scrptr = targetpixel;
+                    }
+                    //scrptr++;
+                }
+                bitmap++;
+                scrptr++;
+            }
+            bitmap += xjump; // needed if x<0 clipping occurs
+        } else { /** ODD pixel starting line **/
+            uint8_t sourcepixel;
+            uint8_t targetpixel;
+            for (scrx = x; scrx < w+x-xclip; scrx+=2) {
+                sourcepixel = *bitmap;
+                targetpixel = *scrptr;
+                // store higher nibble of source pixel in lower nibble of target
+                if((sourcepixel>>4)!=Display::invisiblecolor)
+                    targetpixel = (targetpixel & 0xF0) | (sourcepixel >> 4 );
+                *scrptr = targetpixel;
+                scrptr++;
+                targetpixel = *scrptr;
+                // store lower nibble of source pixel in higher nibble of target
+                if((sourcepixel&0x0F)!=Display::invisiblecolor)
+                    targetpixel = (targetpixel & 0x0F) | (sourcepixel << 4);
+                *scrptr = targetpixel;
+                bitmap++;
+            }
+            if (xclip) {
+                // last line, store higher nibble of last source pixel in lower nibble of last address
+                targetpixel = *scrptr;
+                sourcepixel = *bitmap >> 4;
+                if(sourcepixel!=Display::invisiblecolor)
+                    targetpixel = (targetpixel & 0xF0) | sourcepixel;
+                *scrptr = targetpixel;
+            }
+            bitmap+=xjump;
+        }
+        // increment the y jump in the scrptr
+        scrptr = scrptr + ((width - w)>>1)+scrxjump;
     }
+}
 
-    return;
-    }
-
-    /** 8bpp fast version */
-
-    if (m_colordepth==8) {
+void Display::drawBitmapData8BPP(int x, int y, int w, int h, const uint8_t* bitmap) {
     int16_t scrx,scry;//,scrxjump;
     int16_t xjump=0;
     /** y clipping */
-    if (y<0) { h+=y; bitmap -= y*w; y=0;}
-    else if (y+h>height) { h -=(y-height);}
+    if (y<0) {
+        h += y;
+        bitmap -= y*w;
+        y = 0;
+    } else if (y+h>height) {
+        h -= (y-height);
+    }
+
     /** x clipping */
-    if (x<0) { w+=x; xjump = (-x); bitmap += xjump; x=0;}
-    else if (x+w>width) {
-            xjump=(x+w-width);
-            w = width-x;}
+    if (x<0) {
+        w+=x;
+        xjump = (-x);
+        bitmap += xjump;
+        x=0;
+    } else if (x+w>width) {
+        xjump=(x+w-width);
+        w = width-x;
+    }
 
     uint8_t* scrptr = m_scrbuf + (y*width + x);
     for (scry = y; scry < y+h; scry+=1) {
-            if (scry>=height) return;
-                for (scrx = x; scrx < w+x; scrx++) {
-                    uint8_t sourcepixel = *bitmap;
-                    uint8_t targetpixel = *scrptr;
-                    if (sourcepixel != invisiblecolor ) targetpixel = sourcepixel;
-                    *scrptr = targetpixel;
-                    bitmap++;
-                    scrptr++;
-                }
-            bitmap += xjump; // needed if horizontal clipping occurs
-            scrptr = scrptr + (width - w);
+        if (scry>=height) return;
+        for (scrx = x; scrx < w+x; scrx++) {
+            uint8_t sourcepixel = *bitmap;
+            uint8_t targetpixel = *scrptr;
+            if (sourcepixel != Display::invisiblecolor )
+                targetpixel = sourcepixel;
+            *scrptr = targetpixel;
+            bitmap++;
+            scrptr++;
+        }
+        bitmap += xjump; // needed if horizontal clipping occurs
+        scrptr = scrptr + (width - w);
     }
-    return;
-    }
+}
 
-
+void Display::drawBitmapData(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t* bitmap) {
+    /** visibility check */
+    if (y<-h || y>=height) return; //invisible
+    if (x<-w || x>=width) return;  //invisible
+    if (m_colordepth==2) drawBitmapData2BPP(x, y, w, h, bitmap);
+    if (m_colordepth==4) drawBitmapData4BPP(x, y, w, h, bitmap);
+    if (m_colordepth==8) drawBitmapData8BPP(x, y, w, h, bitmap);
 }
 
 void Display::drawRleBitmap(int16_t x, int16_t y, const uint8_t* rlebitmap)
 {
     // ONLY can copy 4-bit bitmap to 4-bit screen mode for time being
-    #if (POK_SCREENMODE != MODE_FAST_16COLOR)
-    return;
-    #endif
+    if(POK_COLORDEPTH != 4)
+        return;
 
     int16_t w = *rlebitmap;
 	int16_t h = *(rlebitmap + 1);
@@ -1730,219 +1440,200 @@ void Display::drawRleBitmap(int16_t x, int16_t y, const uint8_t* rlebitmap)
     } // end for scry
 }
 
+void Display::drawBitmapDataXFlipped2BPP(int x, int y, int w, int h, const uint8_t* bitmap){
+    int16_t i, j, byteNum, bitNum, byteWidth = w >> 2;
+    for (i = 0; i < w; i++)
+    {
+        byteNum = i / 4;
+        bitNum = (i % 4)<<1;
+        for (j = 0; j < h; j++)
+        {
+            uint8_t source = *(bitmap + j * byteWidth + byteNum);
+            uint8_t output = (source & (0xC0 >> bitNum));
+            output >>= (6-bitNum);
+            if (output != Display::invisiblecolor)
+            {
+                setColor(output);
+                drawPixel(x + i, y + j);
+            }
+        }
+    }
+}
+
+void Display::drawBitmapDataXFlipped4BPP(int x, int y, int w, int h, const uint8_t* bitmap){
+    /** 4bpp fast version */
+    int16_t orgw = w;
+    int16_t scrx,scry,xclip,xjump,scrxjump;
+    xclip=xjump=scrxjump=0;
+    /** y clipping */
+    if (y<0)
+    {
+        h+=y;
+        bitmap -= y*(w>>1);
+        y=0;
+    }
+    else if (y+h>height)
+    {
+        h -=(y-height);
+    }
+    /** x clipping */
+    bitmap += ((w>>1)-1); //inverted!
+    if (x<0)
+    {
+        xclip=(x&1)<<1;
+        w+=x;
+        xjump = ((-x)>>1);
+        bitmap -= xjump;
+        x=0;
+    }
+    else if (x+w>width)
+    {
+        xclip = (x&1)<<1;
+        scrxjump = x&1;
+        xjump=((x+w-width)>>1)+scrxjump;
+        w = width-x;
+    }
+
+    //uint8_t* scrptr = m_scrbuf + (y*(width>>1) + ((x+width)>>1));
+    uint8_t* scrptr = m_scrbuf + (y*(width>>1) + (x>>1));
+    /** ONLY 4-bit mode for time being **/
+    for (scry = y; scry < y+h; scry+=1)
+    {
+        if (scry>=height) return;
+        if ((x&1)==0)   /** EVEN pixel starting line, very simple, just copypaste **/
+        {
+            for (scrx = x; scrx < w+x-xclip; scrx+=2)
+            {
+                uint8_t sourcepixel = *(bitmap);
+                if (xclip)
+                {
+                    sourcepixel >>=4;
+                    sourcepixel |= ((*(bitmap-1))<<4); // inverted nibbles
+                }
+                uint8_t targetpixel = *scrptr;
+                // NIBBLES ARE INVERTED BECAUSE PICTURE IS FLIPPED !!!
+                if ((sourcepixel>>4) != Display::invisiblecolor ) targetpixel = (targetpixel&0xF0) | (sourcepixel>>4);
+                if ((sourcepixel&0x0F) != Display::invisiblecolor) targetpixel = (targetpixel & 0x0F) | (sourcepixel<<4);
+                *scrptr = targetpixel;
+                bitmap--;
+                scrptr++;
+            }
+            if (xclip)
+            {
+                if (w&1)
+                {
+                    /**last pixel is odd pixel due to clipping & odd width*/
+                    uint8_t sourcepixel = *bitmap;
+                    if ((sourcepixel>>4) != Display::invisiblecolor)
+                    {
+                        sourcepixel &= 0xf0;
+                        uint8_t targetpixel = *scrptr & 0x0F;
+                        targetpixel |= sourcepixel;
+                        *scrptr = targetpixel;
+                    }
+                    scrptr++;
+                }
+            }
+            bitmap += (w>>1) + (orgw>>1); // Go the the last (visible) pixel of the next line
+        }
+        else     /** ODD pixel starting line **/
+        {
+            for (scrx = x; scrx < w+x-xclip; scrx+=2 )
+            {
+                uint8_t sourcepixel = *bitmap;
+                uint8_t targetpixel = *scrptr;
+                // inverted !!! store lower nibble of source pixel in lower nibble of target
+                if((sourcepixel&0x0F)!=Display::invisiblecolor) targetpixel = (targetpixel & 0xF0) | (sourcepixel & 0x0F );
+                *scrptr = targetpixel;
+                scrptr++;
+                targetpixel = *scrptr;
+                // inverted ! store higher nibble of source pixel in higher nibble of target
+                if((sourcepixel>>4)!=Display::invisiblecolor) targetpixel = (targetpixel & 0x0F) | (sourcepixel & 0xF0);
+                *scrptr = targetpixel;
+                bitmap--;
+            }
+
+            if (xclip)
+            {
+                if (w&1)
+                {
+                    /**last pixel is odd pixel due to clipping & odd width*/
+                    uint8_t sourcepixel = *bitmap;
+                    if((sourcepixel&0x0F)!=Display::invisiblecolor)
+                    {
+                        //sourcepixel <<=4;
+                        uint8_t targetpixel = *scrptr;// & 0x0F;
+                        targetpixel = (targetpixel & 0xF0) | (sourcepixel & 0x0F );
+                        *scrptr = targetpixel;
+                    }
+                    scrptr++;
+                }
+            }
+            bitmap += (w>>1) + (orgw>>1); // Go the the last (visible) pixel of the next line
+        }
+        // increment the y jump in the scrptr
+        scrptr = scrptr + ((width - w)>>1);
+    }
+}
+
+void Display::drawBitmapDataXFlipped8BPP(int x, int y, int w, int h, const uint8_t* bitmap){
+    int16_t scrx,scry;//,scrxjump;
+    int16_t xjump=0;
+    /** y clipping */
+    if (y<0)
+    {
+        h+=y;
+        bitmap -= y*w;
+        y=0;
+    }
+    else if (y+h>height)
+    {
+        h -=(y-height);
+    }
+    /** x clipping */
+    if (x<0)
+    {
+        w+=x;
+        xjump = (-x);
+        bitmap += xjump;
+        x=0;
+    }
+    else if (x+w>width)
+    {
+        xjump=(x+w-width);
+        w = width-x;
+    }
+
+    uint8_t* scrptr = m_scrbuf + (y*width + x) + w;
+    for (scry = y; scry < y+h; scry+=1)
+    {
+        if (scry>=height) return;
+        for (scrx = x; scrx < w+x; scrx++)
+        {
+            uint8_t sourcepixel = *bitmap;
+            uint8_t targetpixel = *scrptr;
+            if (sourcepixel != Display::invisiblecolor )
+                targetpixel = sourcepixel;
+            *scrptr = targetpixel;
+            bitmap++;
+            scrptr--;
+        }
+        bitmap += xjump; // needed if horizontal clipping occurs
+        scrptr = scrptr + (width + w);
+    }
+}
+
 void Display::drawBitmapDataXFlipped(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t* bitmap)
 {
     /** visibility check */
     if (y<-h || y>height) return; //invisible
     if (x<-w || x>width) return;  //invisible
-    /** 1 bpp mode */
-    if (m_colordepth<2)
-    {
-        int16_t i, j, byteNum, bitNum, byteWidth = (w + 7) >> 3;
-        for (i = 0; i < w; i++)
-        {
-            byteNum = i / 8;
-            bitNum = i % 8;
-            for (j = 0; j < h; j++)
-            {
-                uint8_t source = *(bitmap + j * byteWidth + byteNum);
-                if (source & (0x80 >> bitNum))
-                {
-                    drawPixel(x + w - i, y + j);
-                }
-            }
-        }
-
-        return;
-    }
     /** 2 bpp mode */
-    else if (m_colordepth==2)
-    {
-        int16_t i, j, byteNum, bitNum, byteWidth = w >> 2;
-        for (i = 0; i < w; i++)
-        {
-            byteNum = i / 4;
-            bitNum = (i % 4)<<1;
-            for (j = 0; j < h; j++)
-            {
-                uint8_t source = *(bitmap + j * byteWidth + byteNum);
-                uint8_t output = (source & (0xC0 >> bitNum));
-                output >>= (6-bitNum);
-                if (output != invisiblecolor)
-                {
-                    setColor(output);
-                    drawPixel(x + i, y + j);
-                }
-            }
-        }
-
-        return;
-    }
-    else if (m_colordepth==4)
-    {
-        /** 4bpp fast version */
-        int16_t orgw = w;
-        int16_t scrx,scry,xclip,xjump,scrxjump;
-        xclip=xjump=scrxjump=0;
-        /** y clipping */
-        if (y<0)
-        {
-            h+=y;
-            bitmap -= y*(w>>1);
-            y=0;
-        }
-        else if (y+h>height)
-        {
-            h -=(y-height);
-        }
-        /** x clipping */
-        bitmap += ((w>>1)-1); //inverted!
-        if (x<0)
-        {
-            xclip=(x&1)<<1;
-            w+=x;
-            xjump = ((-x)>>1);
-            bitmap -= xjump;
-            x=0;
-        }
-        else if (x+w>width)
-        {
-            xclip = (x&1)<<1;
-            scrxjump = x&1;
-            xjump=((x+w-width)>>1)+scrxjump;
-            w = width-x;
-        }
-
-        //uint8_t* scrptr = m_scrbuf + (y*(width>>1) + ((x+width)>>1));
-        uint8_t* scrptr = m_scrbuf + (y*(width>>1) + (x>>1));
-        /** ONLY 4-bit mode for time being **/
-        for (scry = y; scry < y+h; scry+=1)
-        {
-            if (scry>=height) return;
-            if ((x&1)==0)   /** EVEN pixel starting line, very simple, just copypaste **/
-            {
-                for (scrx = x; scrx < w+x-xclip; scrx+=2)
-                {
-                    uint8_t sourcepixel = *(bitmap);
-                    if (xclip)
-                    {
-                        sourcepixel >>=4;
-                        sourcepixel |= ((*(bitmap-1))<<4); // inverted nibbles
-                    }
-                    uint8_t targetpixel = *scrptr;
-                    // NIBBLES ARE INVERTED BECAUSE PICTURE IS FLIPPED !!!
-                    if ((sourcepixel>>4) != invisiblecolor ) targetpixel = (targetpixel&0xF0) | (sourcepixel>>4);
-                    if ((sourcepixel&0x0F) != invisiblecolor) targetpixel = (targetpixel & 0x0F) | (sourcepixel<<4);
-                    *scrptr = targetpixel;
-                    bitmap--;
-                    scrptr++;
-                }
-                if (xclip)
-                {
-                    if (w&1)
-                    {
-                        /**last pixel is odd pixel due to clipping & odd width*/
-                        uint8_t sourcepixel = *bitmap;
-                        if ((sourcepixel>>4) != invisiblecolor)
-                        {
-                            sourcepixel &= 0xf0;
-                            uint8_t targetpixel = *scrptr & 0x0F;
-                            targetpixel |= sourcepixel;
-                            *scrptr = targetpixel;
-                        }
-                        scrptr++;
-                    }
-                }
-                bitmap += (w>>1) + (orgw>>1); // Go the the last (visible) pixel of the next line
-            }
-            else     /** ODD pixel starting line **/
-            {
-                for (scrx = x; scrx < w+x-xclip; scrx+=2 )
-                {
-                    uint8_t sourcepixel = *bitmap;
-                    uint8_t targetpixel = *scrptr;
-                    // inverted !!! store lower nibble of source pixel in lower nibble of target
-                    if((sourcepixel&0x0F)!=invisiblecolor) targetpixel = (targetpixel & 0xF0) | (sourcepixel & 0x0F );
-                    *scrptr = targetpixel;
-                    scrptr++;
-                    targetpixel = *scrptr;
-                    // inverted ! store higher nibble of source pixel in higher nibble of target
-                    if((sourcepixel>>4)!=invisiblecolor) targetpixel = (targetpixel & 0x0F) | (sourcepixel & 0xF0);
-                    *scrptr = targetpixel;
-                    bitmap--;
-                }
-
-                if (xclip)
-                {
-                    if (w&1)
-                    {
-                        /**last pixel is odd pixel due to clipping & odd width*/
-                        uint8_t sourcepixel = *bitmap;
-                        if((sourcepixel&0x0F)!=invisiblecolor)
-                        {
-                            //sourcepixel <<=4;
-                            uint8_t targetpixel = *scrptr;// & 0x0F;
-                            targetpixel = (targetpixel & 0xF0) | (sourcepixel & 0x0F );
-                            *scrptr = targetpixel;
-                        }
-                        scrptr++;
-                   }
-                }
-                bitmap += (w>>1) + (orgw>>1); // Go the the last (visible) pixel of the next line
-            }
-            // increment the y jump in the scrptr
-            scrptr = scrptr + ((width - w)>>1);
-        }
-    }
+    if (m_colordepth==2) drawBitmapDataXFlipped2BPP(x, y, w, h, bitmap);
+    else if (m_colordepth==4) drawBitmapDataXFlipped4BPP(x, y, w, h, bitmap);
     /** 8 bpp mode */
-    else if (m_colordepth==8)
-    {
-        int16_t scrx,scry;//,scrxjump;
-        int16_t xjump=0;
-        /** y clipping */
-        if (y<0)
-        {
-            h+=y;
-            bitmap -= y*w;
-            y=0;
-        }
-        else if (y+h>height)
-        {
-            h -=(y-height);
-        }
-        /** x clipping */
-        if (x<0)
-        {
-            w+=x;
-            xjump = (-x);
-            bitmap += xjump;
-            x=0;
-        }
-        else if (x+w>width)
-        {
-            xjump=(x+w-width);
-            w = width-x;
-        }
-
-        uint8_t* scrptr = m_scrbuf + (y*width + x) + w;
-        for (scry = y; scry < y+h; scry+=1)
-        {
-            if (scry>=height) return;
-            for (scrx = x; scrx < w+x; scrx++)
-            {
-                uint8_t sourcepixel = *bitmap;
-                uint8_t targetpixel = *scrptr;
-                if (sourcepixel != invisiblecolor )
-                    targetpixel = sourcepixel;
-                *scrptr = targetpixel;
-                bitmap++;
-                scrptr--;
-            }
-            bitmap += xjump; // needed if horizontal clipping occurs
-            scrptr = scrptr + (width + w);
-        }
-        return;
-    }
+    else if (m_colordepth==8) drawBitmapDataXFlipped8BPP(x, y, w, h, bitmap);
+    
 }
 
 // Note: currently for 4 bpp only
@@ -2129,6 +1820,7 @@ uint8_t* Display::getBuffer() {
     return m_scrbuf;
 }
 
+#endif
 uint8_t Display::getBitmapPixel(const uint8_t* bitmap, uint16_t x, uint16_t y) {
     uint16_t w = *bitmap;
     uint8_t sourcebyte = bitmap[2+(y * ((w+7)>>3))+ (x>>3)];
@@ -2499,6 +2191,7 @@ void Display::printFloat(double number, uint8_t digits)
   }
 }
 
+#if PROJ_SCREENMODE != TASMODE
 
 void Display::draw4BitColumn(int16_t x, int16_t y, uint8_t h, uint8_t* bitmap)
 {
@@ -2528,107 +2221,40 @@ void Display::draw4BitColumn(int16_t x, int16_t y, uint8_t h, uint8_t* bitmap)
                 }
             }
 }
-
-#if (POK_SCREENMODE == MODE_HI_4COLOR)
-
-/**
- * Setup or disable the sprite. Note that enabled sprites must always have subsequent indices, starting from the index zero.
- * You cannot have gaps in indices of enabled sprites.
- * The max number of sprites can be changed by a SPRITE_COUNT define, the default is 4.
- * Note: the sprites currently work only in the 220 x 176 x 2bpp mode.
- * @param index The sprite index. The lower index is drawn first, i.e. is on bottom.
- * @param bitmap A pointer to a 2bpp bitmap. A NULL value means that the sprite is disabled. The ownership is not transferred, so the caller must keep the bitmap alive.
- * @param palette4x16bit Four color palette of 16bit elements. The first color value is considered as transparent. The palette is copied to the sprite struct, so the caller do not have to keep it alive.
- * @param x The initial x
- * @param y The initial y
- * @param doResetDirtyRect (default=true) True, if the previous coordinates are reseted.
- */
-void Display::setSpriteBitmap(uint8_t index, const uint8_t* bitmap,  const uint16_t* palette4x16bit, int16_t x, int16_t y, bool doResetDirtyRect ) {
-
-    setSprite(index, &(bitmap[2]), palette4x16bit, x, y, bitmap[0], bitmap[1], doResetDirtyRect);
-}
-
-/**
- * Setup or disable the sprite. Note that enabled sprites must always have subsequent indices, starting from the index zero.
- * You cannot have gaps in indices of enabled sprites.
- * The max number of sprites can be changed by a SPRITE_COUNT define, the default is 4.
- * Note: the sprites currently work only in the 220 x 176 x 2bpp mode.
- * @param index The sprite index. The lower index is drawn first, i.e. is on bottom. Note that
- * @param data A pointer to a 2bpp pixel data of size w x h. A NULL value means that the sprite is disabled. The ownership is not transferred, so the caller must keep the data alive.
- * @param palette4x16bit Four color palette of 16bit elements. The first color value is considered as transparent. The palette is copied to the sprite struct, so the caller do not have to keep it alive.
- * @param x The initial x
- * @param y The initial y
- * @param w Width
- * @param h Height
- */
-void Display::setSprite(uint8_t index, const uint8_t* data, const uint16_t* palette4x16bit, int16_t x, int16_t y, uint8_t w, uint8_t h, bool doResetDirtyRect ) {
-
-    if(index >= SPRITE_COUNT) return;
-    m_sprites[index].bitmapData = data;
-    m_sprites[index].x = x;
-    m_sprites[index].y = y;
-    if (doResetDirtyRect) {
-        m_sprites[index].oldx = x;
-        m_sprites[index].oldy = y;
-    }
-    m_sprites[index].w = w;
-    m_sprites[index].h = h;
-    if( palette4x16bit ) memcpy(m_sprites[index].palette, palette4x16bit, 4*2);
-}
-
-/**
- * Set the sprite position.
- * @param index The sprite index
- * @param x
- * @param y
- */
-void Display::setSpritePos(uint8_t index, int16_t x, int16_t y) {
-
-    if(index >= SPRITE_COUNT) return;
-    m_sprites[index].x = x;
-    m_sprites[index].y = y;
-}
-
 #endif
 
-void Display::lcdRefresh(unsigned char* scr, bool useDirectDrawMode) {
-
-#if POK_SCREENMODE == MODE_HI_4COLOR
-    // If there is one or more sprites, use sprite enabled drawing.
-    if (m_sprites[0].bitmapData != NULL)
-        lcdRefreshMode1Spr(scr, 0, 0, LCDWIDTH, LCDHEIGHT, paletteptr, m_sprites, useDirectDrawMode);
-    else if (!useDirectDrawMode)
-        lcdRefreshMode1(m_scrbuf, 0, 0, LCDWIDTH, LCDHEIGHT, paletteptr);
+void Display::lcdRefresh(const unsigned char* scr, bool useDirectDrawMode) {
+    if (useDirectDrawMode)
+        return;
+#if PROJ_SCREENMODE != MODE_NOBUFFER
+    lcdPrepareRefresh();
+#endif
+#if PROJ_SCREENMODE == TASMODE
+    lcdRefreshTASMode(const_cast<uint8_t*>(scr), paletteptr);
 #endif
 
-    // For the screen modes that do not support sprites, return if the direct draw mode is used.
-    if (useDirectDrawMode) return;
-#if POK_SCREENMODE == MODE13
-    lcdRefreshMode13(m_scrbuf, paletteptr, palOffset);
+#if PROJ_SCREENMODE == MODE_HI_4COLOR
+    lcdRefreshMode1(scr, paletteptr);
 #endif
 
-#if POK_SCREENMODE == MIXMODE
-    lcdRefreshMixMode(m_scrbuf, paletteptr, scanType);
+#if PROJ_SCREENMODE == MODE13
+    lcdRefreshMode13(scr, paletteptr, palOffset);
 #endif
 
-#if POK_SCREENMODE == MODE64
-    lcdRefreshMode64(m_scrbuf, paletteptr);
+#if PROJ_SCREENMODE == MODE15
+    lcdRefreshMode15(scr, paletteptr);
 #endif
 
-#if POK_SCREENMODE == MODE_GAMEBOY
-    lcdRefreshModeGBC(scr, paletteptr);
+#if PROJ_SCREENMODE == MIXMODE
+    lcdRefreshMixMode(scr, paletteptr, scanType);
 #endif
 
-#if POK_SCREENMODE == MODE_FAST_16COLOR
+#if PROJ_SCREENMODE == MODE64
+    lcdRefreshMode64(scr, paletteptr);
+#endif
+
+#if PROJ_SCREENMODE == MODE_FAST_16COLOR
     lcdRefreshMode2(scr, paletteptr);
-#endif
-
-#if POK_SCREENMODE == MODE_GAMEBUINO_16COLOR
-    lcdRefreshGB(scr, paletteptr);
-#endif
-
-#if POK_SCREENMODE == MODE_ARDUBOY_16COLOR
-    lcdRefreshAB(scr, paletteptr);
 #endif
 
 }
@@ -2636,22 +2262,6 @@ void Display::lcdRefresh(unsigned char* scr, bool useDirectDrawMode) {
 void Display::setFrameBufferTo(uint8_t* sb) {
     m_scrbuf = sb;
 };
-
-#if (POK_SCREENMODE == MODE_TILED_1BIT)
-void Display::setTileBufferTo(uint8_t* tb) {
-    m_tilebuf = tb;
-};
-
-void Display::loadTileset(const uint8_t* ts) {
-    m_tileset = (uint8_t*) ts;
-};
-
-void Display::setTile(uint16_t i, uint8_t t) {
-    if (!m_tilebuf) return;
-    m_tilebuf[i]=t;
-};
-#endif
-
 
 // Convert an integer to a hexadecimal string
 char* itoa_hex(int num, char* dest, int destLen) {
@@ -2731,7 +2341,7 @@ void CheckStack() {
         const int infoStringLen = 8+1+8;
         static char infoString[infoStringLen+1];
         memset(infoString,0,infoStringLen+1);
-        const int stackSize = (int)_vStackTop - (int)&currStackTop;
+        const int stackSize = reinterpret_cast<uintptr_t>(_vStackTop) - reinterpret_cast<uintptr_t>(&currStackTop);
         const int tmpStrLen = 8;
         static char tmpStr[tmpStrLen+1];
         memset(tmpStr,0,tmpStrLen+1);

--- a/Pokitto/POKITTO_CORE/PokittoDisplay.h
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.h
@@ -125,16 +125,9 @@ const uint16_t def565palette[16] = {
     0x2d7f, 0x83b3, 0xfbb5, 0xfe75
 };
 
-#if ((POK_SCREENMODE==MODE_FAST_16COLOR) || (POK_SCREENMODE==MODE15) || (POK_SCREENMODE==MODE_HI_16COLOR))
-    #define PALETTE_SIZE 16
-#else
-    #define PALETTE_SIZE 256
-#endif
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-
 
 namespace Pokitto {
 
@@ -142,22 +135,11 @@ class Display {
 public:
     Display();
 
-    // PROPERTIES
-private:
-    //static uint8_t* canvas;
-    //static uint8_t bpp;
-public:
-    static uint8_t m_colordepth; // public to be used elsewhere
-#if (POK_SCREENMODE == MIXMODE)
-    static uint8_t subMode; // for mixed mode switching
-#endif
+    static uint8_t m_colordepth;
     static uint8_t palOffset;
     static uint8_t width;
     static uint8_t height;
     static uint8_t screenbuffer[];
-#if (POK_SCREENMODE == MIXMODE)
-    static uint8_t scanType[]; // for mixed screen mode
-#endif
 
     // PROPERTIES
     static void setColorDepth(uint8_t);
@@ -165,7 +147,7 @@ public:
     static uint8_t getBitsPerPixel();
     static uint16_t getWidth();
     static uint16_t getHeight();
-    static uint8_t getNumberOfColors();
+    static uint32_t getNumberOfColors();
 
     // IMPORTANT PUBLIC STATE MEMBERS
     /** Selected font */
@@ -184,13 +166,6 @@ public:
     static uint16_t directbgcolor;
     /** Direct text rotated */
     static bool directtextrotated;
-    #if (POK_COLORDEPTH == 2)
-    /** clip rect on screen**/
-    static int16_t clipX;
-    static int16_t clipY;
-    static int16_t clipW;
-    static int16_t clipH;
-    #endif
     /** set color with a command */
     static void setColor(uint8_t);
     /** set color and bgcolor with a command */
@@ -203,12 +178,6 @@ public:
     static uint8_t getBgColor();
     /** get invisible color */
     static uint16_t getInvisibleColor();
-
-    #if (POK_COLORDEPTH == 2)
-    /** set clip rect on screen**/
-    static void setClipRect(int16_t x, int16_t y, int16_t w, int16_t h);
-    #endif
-
     /** Initialize display */
     static void begin();
     /** Clear display buffer */
@@ -218,9 +187,9 @@ public:
     /** Fill display buffer */
     static void fillScreen(uint16_t);
     /** Send display buffer to display hardware */
-    static void update(bool useDirectMode=false, uint8_t updRectX=0, uint8_t updRectY=0, uint8_t updRectW=LCDWIDTH, uint8_t updRectH=LCDHEIGHT);
+    static void update(bool useDirectMode=false);
     /** Forced update of LCD display memory with a given pixel buffer */
-    static void lcdRefresh(unsigned char*, bool useDirectMode=false);
+    static void lcdRefresh(const unsigned char*, bool useDirectMode=false);
     /** Clear LCD hardware memory */
     static void clearLCD();
     /** Fill LCD hardware memory */
@@ -231,7 +200,6 @@ public:
     static void setFrameBufferTo(uint8_t*);
 
     // COLORS AND PALETTE
-public:
     /** set default palette */
     static void setDefaultPalette();
     /** master palette */
@@ -255,7 +223,7 @@ public:
     /** Direct pixel (not through display buffer) */
     static void directPixel(int16_t,int16_t,uint16_t);
     /** Direct tile 16bit (not through display buffer) */
-	static void directTile(int16_t x, int16_t y, int16_t x2, int16_t y2, uint16_t* gfx);
+    static void directTile(int16_t x, int16_t y, int16_t x2, int16_t y2, uint16_t* gfx);
     /** Direct rectangle (not through display buffer) */
     static void directRectangle(int16_t, int16_t,int16_t, int16_t, uint16_t);
     /** Set the cursor for printing to a certain screen position */
@@ -303,21 +271,28 @@ public:
     /** Draw circle */
     static void drawCircle(int16_t x0, int16_t y0, int16_t r);
     /** Draw circle helper */
-	static void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint16_t cornername);
-	/** Fill circle */
-	static void fillCircle(int16_t x0, int16_t y0, int16_t r);
-	/** Fill circle helper*/
-	static void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint16_t cornername, int16_t delta);
-	/** draw triangle */
-	static void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2);
-	/** Fill triangle*/
-	static void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2);
-	/** Draw rounded rectangle */
-	static void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius);
-	/** Fill rounded rectangle */
-	static void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius);
+    static void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint16_t cornername);
+    /** Fill circle */
+    static void fillCircle(int16_t x0, int16_t y0, int16_t r);
+    /** Fill circle helper*/
+    static void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint16_t cornername, int16_t delta);
+    /** draw triangle */
+    static void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2);
+    /** Fill triangle*/
+    static void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2);
+    /** Draw rounded rectangle */
+    static void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius);
+    /** Fill rounded rectangle */
+    static void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius);
 
     // BITMAPS !
+    #if PROJ_SCREENMODE == TASMODE
+    /** Draw tile in Tiles-and-Sprites mode. X&Y are in tile-space, not pixels. */
+    static void drawTile(uint32_t x, uint32_t y, const uint8_t *data);
+    /** Draw sprite in Tiles-And-Sprites mode */
+    static void drawSprite(int x, int y, const uint8_t *data, bool flipped=0, bool mirrored=0, uint8_t recolor=0);
+    static void shiftTilemap(int x, int y);
+    #else
     /** Draw monochromatic bitmap. Used in font rendering */
     static void drawMonoBitmap(int16_t x, int16_t y, const uint8_t* bitmap, uint8_t index);
     /** Draw bitmap data*/
@@ -327,51 +302,51 @@ public:
     /** Draw RLE bitmap */
     static void drawRleBitmap(int16_t x, int16_t y, const uint8_t* bitmap);
 
-	/// \brief
-	/// Draws a single frame of a multi-frame bitmap
-	/// \param x The x coordinate to draw the bitmap frame at
-	/// \param y The y coordinate to draw the bitmap frame at
-	/// \param bitmap The multi-frame bitmap whose frame is to be drawn
-	/// \param frameIndex The index of the frame to be drawn
-	/// \details
-	/// A multi-frame bitmap is expected to be in a particular format.
-	/// The 0th byte of the bitmap should be the width of the bitmap's frames.
-	/// The 1st byte of the bitmap should be the height of the bitmap's frames.
-	/// The remaining bytes should consist of the frames of the multi-frame bitmap,
-	/// stored one after another without any kind of separator or terminator.
-	///
-	/// Example bitmap:
-	/// \code{.cpp}
-	/// #pragma once
-	/// 
-	/// #include <cstdint>
-	/// 
-	/// // An example bitmap, in 4bpp mode
-	/// const std::uint8_t exampleBitmap[] =
-	/// {
-	/// 	// Width, Height
-	/// 	8, 8,
-	/// 	// Frame 0
-	/// 	0x11, 0x11, 0x11, 0x11,
-	/// 	0x10, 0x00, 0x00, 0x01,
-	/// 	0x10, 0x00, 0x00, 0x01,
-	/// 	0x10, 0x00, 0x00, 0x01,
-	/// 	0x10, 0x00, 0x00, 0x01,
-	/// 	0x10, 0x00, 0x00, 0x01,
-	/// 	0x10, 0x00, 0x00, 0x01,
-	/// 	0x11, 0x11, 0x11, 0x11,
-	/// 	// Frame 1
-	/// 	0x22, 0x22, 0x22, 0x22,
-	/// 	0x20, 0x00, 0x00, 0x02,
-	/// 	0x20, 0x00, 0x00, 0x02,
-	/// 	0x20, 0x00, 0x00, 0x02,
-	/// 	0x20, 0x00, 0x00, 0x02,
-	/// 	0x20, 0x00, 0x00, 0x02,
-	/// 	0x20, 0x00, 0x00, 0x02,
-	/// 	0x22, 0x22, 0x22, 0x22,
-	/// };
-	/// \endcode
-	static void drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frameIndex);
+    /// \brief
+    /// Draws a single frame of a multi-frame bitmap
+    /// \param x The x coordinate to draw the bitmap frame at
+    /// \param y The y coordinate to draw the bitmap frame at
+    /// \param bitmap The multi-frame bitmap whose frame is to be drawn
+    /// \param frameIndex The index of the frame to be drawn
+    /// \details
+    /// A multi-frame bitmap is expected to be in a particular format.
+    /// The 0th byte of the bitmap should be the width of the bitmap's frames.
+    /// The 1st byte of the bitmap should be the height of the bitmap's frames.
+    /// The remaining bytes should consist of the frames of the multi-frame bitmap,
+    /// stored one after another without any kind of separator or terminator.
+    ///
+    /// Example bitmap:
+    /// \code{.cpp}
+    /// #pragma once
+    /// 
+    /// #include <cstdint>
+    /// 
+    /// // An example bitmap, in 4bpp mode
+    /// const std::uint8_t exampleBitmap[] =
+    /// {
+    /// 	// Width, Height
+    /// 	8, 8,
+    /// 	// Frame 0
+    /// 	0x11, 0x11, 0x11, 0x11,
+    /// 	0x10, 0x00, 0x00, 0x01,
+    /// 	0x10, 0x00, 0x00, 0x01,
+    /// 	0x10, 0x00, 0x00, 0x01,
+    /// 	0x10, 0x00, 0x00, 0x01,
+    /// 	0x10, 0x00, 0x00, 0x01,
+    /// 	0x10, 0x00, 0x00, 0x01,
+    /// 	0x11, 0x11, 0x11, 0x11,
+    /// 	// Frame 1
+    /// 	0x22, 0x22, 0x22, 0x22,
+    /// 	0x20, 0x00, 0x00, 0x02,
+    /// 	0x20, 0x00, 0x00, 0x02,
+    /// 	0x20, 0x00, 0x00, 0x02,
+    /// 	0x20, 0x00, 0x00, 0x02,
+    /// 	0x20, 0x00, 0x00, 0x02,
+    /// 	0x20, 0x00, 0x00, 0x02,
+    /// 	0x22, 0x22, 0x22, 0x22,
+    /// };
+    /// \endcode
+    static void drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, uint8_t frameIndex);
 
     /** Draw bitmap data flipped on x-axis*/
     static void drawBitmapDataXFlipped(int16_t x, int16_t y, int16_t w, int16_t h, const uint8_t* bitmap);
@@ -385,18 +360,11 @@ public:
     static void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t rotation, uint8_t flip);
     /** Get pointer to the screen buffer - GB compatibility */
     static uint8_t* getBuffer();
-    /** Get pixel in a monochromatic bitmap - GB compatibility */
-    static uint8_t getBitmapPixel(const uint8_t*, uint16_t, uint16_t);
     /** Optimized functions for drawing bit columns - used in raytracing */
     static void draw4BitColumn(int16_t x, int16_t y, uint8_t h, uint8_t* bitmap);
-
-    // SPRITES
-    /* Setup or disable the sprite */
-    static void setSpriteBitmap(uint8_t index, const uint8_t* bitmap, const uint16_t* palette4x16bit, int16_t x, int16_t y, bool doResetDirtyRect=true );
-    /* Setup or disable the sprite */
-    static void setSprite(uint8_t index, const uint8_t* data, const uint16_t* palette4x16bit, int16_t x, int16_t y, uint8_t w, uint8_t h, bool doResetDirtyRect=true );
-    /* Set the sprite position */
-    static void setSpritePos(uint8_t index, int16_t x, int16_t y);
+    #endif
+    /** Get pixel in a monochromatic bitmap - GB compatibility */
+    static uint8_t getBitmapPixel(const uint8_t*, uint16_t, uint16_t);
 
     // PRINTING
     /** direct character to screen (no buffering) */
@@ -454,11 +422,10 @@ public:
     static void println(double, int = 2);
     static void println(void);
 
-
     static int16_t cursorX,cursorY;
     static uint8_t fontSize;
     static int8_t adjustCharStep, adjustLineStep;
-	static bool fixedWidthFont, flipFontVertical;
+    static bool fixedWidthFont, flipFontVertical;
 
     static void inc_txtline();
     static void printNumber(unsigned long, uint8_t);
@@ -467,41 +434,24 @@ public:
     /** external small printf, source in PokittoPrintf.cpp **/
     static int printf(const char *format, ...);
 
-#if (POK_SCREENMODE == MODE_TILED_1BIT)
-    /** Tiled mode functions **/
-
-    static void loadTileset(const uint8_t*);
-
-    static void setTileBufferTo(uint8_t*);
-    static void clearTileBuffer();
-    static void shiftTileBuffer(int8_t,int8_t);
-
-    static void setTile(uint16_t,uint8_t);
-    static uint8_t getTile(uint16_t);
-    static uint8_t getTile(uint8_t,uint8_t);
+#if (POK_SCREENMODE == MIXMODE)
+    static uint8_t subMode; // for mixed mode switching
+    static uint8_t scanType[]; // for mixed screen mode
 #endif
 
-
 private:
+    void printFPS();
     static uint8_t m_mode;
     static uint8_t m_w,m_h; // store these for faster access when switching printing modes
     /** Pointer to screen buffer */
     static uint8_t* m_scrbuf;
 
-#if (POK_SCREENMODE == MODE_TILED_1BIT)
-    /** Pointer to tileset */
-    static uint8_t* m_tileset;
-    /** Pointer to tilebuffer */
-    static uint8_t* m_tilebuf;
-    /** Pointer to tilecolorbuffer */
-    static uint8_t* m_tilecolorbuf;
-#endif
-
-    /** Sprites */
-#if (POK_SCREENMODE == MODE_HI_4COLOR)
-    static SpriteInfo m_sprites[SPRITE_COUNT];  // Does not own sprite bitmaps
-#endif
-
+    static void drawBitmapData2BPP(int x, int y, int w, int h, const uint8_t* bitmap);
+    static void drawBitmapData4BPP(int x, int y, int w, int h, const uint8_t* bitmap);
+    static void drawBitmapData8BPP(int x, int y, int w, int h, const uint8_t* bitmap);
+    static void drawBitmapDataXFlipped2BPP(int x, int y, int w, int h, const uint8_t* bitmap);
+    static void drawBitmapDataXFlipped4BPP(int x, int y, int w, int h, const uint8_t* bitmap);
+    static void drawBitmapDataXFlipped8BPP(int x, int y, int w, int h, const uint8_t* bitmap);
 };
 
 }

--- a/Pokitto/POKITTO_CORE/PokittoFakeavr.h
+++ b/Pokitto/POKITTO_CORE/PokittoFakeavr.h
@@ -82,10 +82,6 @@ typedef uint8_t byte;
 /** min max & others **/
 
 
-#ifndef DISABLEAVRMIN
-#define max(a,b) ((a)>(b)?(a):(b))
-#define min(a,b) ((a)<(b)?(a):(b))
-#endif // DISABLEAVRMIN
 #define __avrmax(a,b) ((a)>(b)?(a):(b))
 #define __avrmin(a,b) ((a)<(b)?(a):(b))
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))

--- a/Pokitto/POKITTO_CORE/PokittoPalette.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoPalette.cpp
@@ -46,43 +46,43 @@ Software License Agreement (BSD License)
 #include "SimLCD.h"
 #endif
 
-#if PROJ_SCREENMODE != 13 && PROJ_SCREENMODE != 64 && !defined(PROJ_MODE13) && !defined(PROJ_MODE64)
-#define PALSIZE 16
-#else
-#define PALSIZE 256
-#endif
-
 using namespace Pokitto;
 
 
 void Display::loadRGBPalette(const unsigned char* p) {
-    for (int i=0;i<PALSIZE;i++) palette[i] = RGBto565(p[i*3], p[i*3+1],p[i*3+2]);
+    for (int i=0;i<PALETTE_SIZE;i++)
+        palette[i] = RGBto565(p[i*3], p[i*3+1],p[i*3+2]);
     paletteptr = palette;
 }
 
 void Display::load565Palette(const uint16_t* p) {
-    for (int i=0;i<PALSIZE;i++) palette[i] = p[i];
+    for (int i=0;i<PALETTE_SIZE;i++)
+        palette[i] = p[i];
     paletteptr = palette;
 }
 
 void Display::rotatePalette(int8_t step) {
-    uint16_t tpal[PALSIZE];
+    uint16_t tpal[PALETTE_SIZE];
     if (step == 0) return;
     step = 0-step;
     if (step>0) {
-        for (int i=step;i<PALSIZE;i++) tpal[i]=palette[i-step]; // palette revolves up, new color 1 becomes old color 0
-        for (int i=0; i < step; i++) tpal[i]=palette[PALSIZE-step+i]; // overflow topmost values to bottom of new palette
+        for (int i=step;i<PALETTE_SIZE;i++)
+            tpal[i]=palette[i-step]; // palette revolves up, new color 1 becomes old color 0
+        for (int i=0; i < step; i++)
+            tpal[i]=palette[PALETTE_SIZE-step+i]; // overflow topmost values to bottom of new palette
     } else {
-        for (int i=0;i<PALSIZE+step;i++)
+        for (int i=0;i<PALETTE_SIZE+step;i++)
         {
             tpal[i]=palette[i-step];
             }// palette revolves down, new color 0 becomes old color 1
         for (int i=0;i<-step; i++) {
-                tpal[PALSIZE+step+i]=palette[i];
+                tpal[PALETTE_SIZE+step+i]=palette[i];
         }
         // overflow bottom values to top of new palette
     }
-    for (int i=0; i<PALSIZE;i++) palette[i] = tpal[i];
+
+    for (int i=0; i<PALETTE_SIZE;i++)
+        palette[i] = tpal[i];
 }
 
 uint16_t Display::RGBto565(uint8_t R,uint8_t G,uint8_t B) {

--- a/Pokitto/POKITTO_CORE/PokittoPrintf.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoPrintf.cpp
@@ -45,11 +45,11 @@ static void printchar(char **str, int c)
 
 static int prints(char **out, const char *string, int width, int pad)
 {
-	register int pc = 0, padchar = ' ';
+	int pc = 0, padchar = ' ';
 
 	if (width > 0) {
-		register int len = 0;
-		register const char *ptr;
+		int len = 0;
+		const char *ptr;
 		for (ptr = string; *ptr; ++ptr) ++len;
 		if (len >= width) width = 0;
 		else width -= len;
@@ -79,9 +79,9 @@ static int prints(char **out, const char *string, int width, int pad)
 static int printi(char **out, int i, int b, int sg, int width, int pad, int letbase)
 {
 	char print_buf[PRINT_BUF_LEN];
-	register char *s;
-	register int t, neg = 0, pc = 0;
-	register unsigned int u = i;
+	char *s;
+	int t, neg = 0, pc = 0;
+	unsigned int u = i;
 
 	if (i == 0) {
 		print_buf[0] = '0';
@@ -121,9 +121,9 @@ static int printi(char **out, int i, int b, int sg, int width, int pad, int letb
 
 static int _ext_print(char **out, int *varg)
 {
-	register int width, pad;
-	register int pc = 0;
-	register char *format = (char *)(*varg++);
+	int width, pad;
+	int pc = 0;
+	char *format = (char *)(*varg++);
 	char scr[2];
 
 	for (; *format != 0; ++format) {
@@ -145,7 +145,7 @@ static int _ext_print(char **out, int *varg)
 				width += *format - '0';
 			}
 			if( *format == 's' ) {
-				register char *s = *((char **)varg++);
+				char *s = *((char **)varg++);
 				pc += prints (out, s?s:"(null)", width, pad);
 				continue;
 			}
@@ -187,13 +187,13 @@ static int _ext_print(char **out, int *varg)
 
 int _ext_printf(const char *format, ...)
 {
-	register int *varg = (int *)(&format);
+	int *varg = (int *)(&format);
 	return _ext_print(0, varg);
 }
 
 int _ext_sprintf(char *out, const char *format, ...)
 {
-	register int *varg = (int *)(&format);
+	int *varg = (int *)(&format);
 	return _ext_print(&out, varg);
 }
 
@@ -204,7 +204,7 @@ int _ext_sprintf(char *out, const char *format, ...)
  */
 
 int Pokitto::Display::printf(const char *format, ...) {
-    register int *varg = (int *)(&format);
+    int *varg = (int *)(&format);
 	return _ext_print(0, varg);
 };
 

--- a/Pokitto/POKITTO_CORE/TASMODE.cpp
+++ b/Pokitto/POKITTO_CORE/TASMODE.cpp
@@ -24,14 +24,19 @@ uint32_t spriteBufferPos = 0;
 
 using Tilemap = uint8_t const * const *;
 constexpr uint32_t tileW = POK_TILE_W;
-constexpr uint32_t tileH = POK_TILE_W;
-constexpr uint32_t mapW = POK_LCD_W / tileW + 1;
-constexpr uint32_t mapH = POK_LCD_H / tileH + 1;
+constexpr uint32_t tileH = POK_TILE_H;
+constexpr uint32_t mapW = POK_LCD_W / tileW + 2;
+constexpr uint32_t mapH = POK_LCD_H / tileH + 2;
 const uint8_t *tilemap[mapH * mapW];
 uint32_t cameraX;
 uint32_t cameraY;
 
 void Display::shiftTilemap(int x, int y){
+    if(x<0) x = 0;
+    if(x>=tileW) x=tileW-1;
+    if(y<0) y = 0;
+    if(y>=tileH) y=tileH-1;
+    
     cameraX = x % tileW;
     cameraY = y % tileH;
 }
@@ -181,11 +186,10 @@ void lcdRefreshTASMode(uint8_t *line, const uint16_t* palette){
         }
     }
 
-    Tilemap  tileWindow = tilemap - 1;
-    uint32_t tileY = tileH;
-    uint32_t tileX;
+    Tilemap  tileWindow = tilemap;
+    uint32_t tileY = tileH - cameraY;
+    uint32_t tileX = cameraX;
     uint32_t tileIndex = cameraY * tileW;
-    uint32_t tilesToDraw = (220 / tileW) + 1;
     
     for(uint32_t y=0; y<176; ++y, tileIndex += tileW){
         if(!tileY--){
@@ -193,8 +197,8 @@ void lcdRefreshTASMode(uint8_t *line, const uint16_t* palette){
             tileY = tileH - 1;
             tileWindow += mapW;
         }
-        tileX = tileW - cameraX;
 
+        tileX = cameraX;
         uint32_t tile = 0;
         for(uint32_t i=0; i<220;){
             auto tileData = tileWindow[tile] + tileX + tileIndex;

--- a/Pokitto/POKITTO_CORE/TASMODE.cpp
+++ b/Pokitto/POKITTO_CORE/TASMODE.cpp
@@ -1,0 +1,223 @@
+#include "Pokitto.h"
+
+#if PROJ_SCREENMODE == TASMODE
+
+using namespace Pokitto;
+
+enum class SpriteMode : uint8_t {
+    copy,
+    mirror,
+    flip,
+    flipmirror
+};
+
+struct Sprite { 
+    int16_t x, y; 
+    SpriteMode mode; 
+    uint8_t height;
+    uint8_t recolor;
+    const uint8_t *data;
+};
+
+Sprite spriteBuffer[PROJ_MAX_SPRITES];
+uint32_t spriteBufferPos = 0;
+
+using Tilemap = uint8_t const * const *;
+constexpr uint32_t tileW = POK_TILE_W;
+constexpr uint32_t tileH = POK_TILE_W;
+constexpr uint32_t mapW = POK_LCD_W / tileW + 1;
+constexpr uint32_t mapH = POK_LCD_H / tileH + 1;
+const uint8_t *tilemap[mapH * mapW];
+uint32_t cameraX;
+uint32_t cameraY;
+
+void Display::shiftTilemap(int x, int y){
+    cameraX = x % tileW;
+    cameraY = y % tileH;
+}
+
+void Display::drawTile(uint32_t x, uint32_t y, const uint8_t *data){
+    if(x >= mapW || y >= mapH)
+        return;
+    tilemap[y*mapW + x] = data;
+}
+
+void Display::drawSprite(int x, int y, const uint8_t *data, bool flipped, bool mirrored, uint8_t recolor){
+    if(y >= 176 || y + data[1] < 0 || x >= 220 || x + data[0] < 0) return;
+    if(spriteBufferPos == PROJ_MAX_SPRITES) spriteBufferPos = 0;
+    auto mode = flipped ?
+        (mirrored ? SpriteMode::flipmirror : SpriteMode::flip):
+        (mirrored ? SpriteMode::mirror     : SpriteMode::copy);
+    spriteBuffer[spriteBufferPos++] = Sprite{x, y, mode, y + data[1], recolor, data};
+}
+
+void blit(uint8_t *line, Sprite &s, int y){
+    int w = s.data[0];
+    const uint8_t *src = s.data + 2 + y * w;
+    if(s.x < 0){
+        src -= s.x;
+        w += s.x;
+    }else if(s.x > 0){
+        line += s.x;
+    }
+    if(s.x + w >= 220){
+        w = 220 - s.x;
+    }
+    /* */
+    pixelCopy(line, src, w, s.recolor);
+    /*/
+    while(w--){
+        if(*src)
+            *line = *src;
+        line++;
+        src++;
+    }
+    /* */
+}
+
+void blitMirror(uint8_t *line, Sprite &s, int y){
+    int w = s.data[0];
+    const uint8_t *src = s.data + 2 + y * w + w - 1;
+    if(s.x < 0){
+        w += s.x;
+    }else if(s.x > 0){
+        line += s.x;
+    }
+    if(s.x + w >= 220){
+        src -= 220 - (s.x + w);
+        w = 220 - s.x;
+    }
+    /* */
+    pixelCopyMirror(line, src - w + 1, w, s.recolor);
+    /*/
+    while(w--){
+        if(*src)
+            *line = *src;
+        line++;
+        src--;
+    }
+    /* */
+}
+
+void blitFlip(uint8_t *line, Sprite &s, int y){
+    int w = s.data[0];
+    int h = s.data[1];
+    const uint8_t *src = s.data + 2 + (h - 1 - y) * w;
+    if(s.x < 0){
+        src -= s.x;
+        w += s.x;
+    }else if(s.x > 0){
+        line += s.x;
+    }
+    if(s.x + w >= 220){
+        w = 220 - s.x;
+    }
+    pixelCopy(line, src, w, s.recolor);
+    /*
+    while(w--){
+        if(*src)
+            *line = *src;
+        line++;
+        src++;
+    }
+    */
+}
+
+void blitFlipMirror(uint8_t *line, Sprite &s, int y){
+    int w = s.data[0];
+    int h = s.data[1];
+    const uint8_t *src = s.data + 2 + (h - 1 - y) * w + w - 1;
+    if(s.x < 0){
+        w += s.x;
+    }else if(s.x > 0){
+        line += s.x;
+    }
+    if(s.x + w >= 220){
+        src -= 220 - (s.x + w);
+        w = 220 - s.x;
+    }
+    /* */
+    pixelCopyMirror(line, src - w + 1, w, s.recolor);
+    /*/
+    while(w--){
+        if(*src)
+            *line = *src;
+        line++;
+        src--;
+    }
+    /* */
+}
+
+using Blitter = void (*)(uint8_t *, Sprite &sprite, int y );
+
+const Blitter blitters[] = {
+    blit,
+    blitMirror,
+    blitFlip,
+    blitFlipMirror
+};
+
+void drawSprites(int y, uint8_t *line, int max){
+    if(!max) return;
+    for(uint32_t i=0; i<spriteBufferPos; ++i){
+        auto& s = spriteBuffer[i];
+        if( s.y > y || s.height <= y ) continue;
+        auto blitter = blitters[static_cast<uint32_t>(s.mode)];
+        blitter(line, s, y - s.y);
+        if(!--max) break;
+    }
+}
+
+namespace Pokitto {
+
+void lcdRefreshTASMode(uint8_t *line, const uint16_t* palette){
+    uint8_t spritesPerLine[176];
+    for(int y=0; y<176; ++y) spritesPerLine[y] = 0;
+
+    for(uint32_t i=0; i<spriteBufferPos; ++i){
+        auto& s = spriteBuffer[i];
+        for(int y=s.y; y<s.height; ++y){
+            spritesPerLine[y]++;
+        }
+    }
+
+    Tilemap  tileWindow = tilemap - 1;
+    uint32_t tileY = tileH;
+    uint32_t tileX;
+    uint32_t tileIndex = cameraY * tileW;
+    uint32_t tilesToDraw = (220 / tileW) + 1;
+    
+    for(uint32_t y=0; y<176; ++y, tileIndex += tileW){
+        if(!tileY--){
+            tileIndex = 0;
+            tileY = tileH - 1;
+            tileWindow += mapW;
+        }
+        tileX = tileW - cameraX;
+
+        uint32_t tile = 0;
+        for(uint32_t i=0; i<220;){
+            auto tileData = tileWindow[tile] + tileX + tileIndex;
+            int iter = std::min(tileW - tileX, 220 - i);
+            /* */
+            pixelCopySolid(line+i, tileData, iter);
+            i += iter;
+            /*/
+            while(iter--){
+                line[i++] = *tileData++;
+            }
+            /* */
+            tileX = 0;
+            tile++;
+        }
+
+        drawSprites(y, line, spritesPerLine[y]);
+        flushLine(palette, line);
+    }
+    
+    spriteBufferPos = 0;
+}
+
+}
+
+#endif

--- a/Pokitto/POKITTO_HW/HWLCD.cpp
+++ b/Pokitto/POKITTO_HW/HWLCD.cpp
@@ -1,40 +1,40 @@
 /**************************************************************************/
 /*!
-    @file     HWLCD.cpp
-    @author   Jonne Valola
+  @file     HWLCD.cpp
+  @author   Jonne Valola
 
-    @section LICENSE
+  @section LICENSE
 
-    Software License Agreement (BSD License)
+  Software License Agreement (BSD License)
 
-    Copyright (c) 2016, Jonne Valola
-    All rights reserved.
+  Copyright (c) 2016, Jonne Valola
+  All rights reserved.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holders nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holders nor the
+  names of its contributors may be used to endorse or promote products
+  derived from this software without specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /**************************************************************************/
 
-#include "HWLCD.h" //HWLCD.h" #include "HWLCD.h"
+#include "HWLCD.h"
 #include "Pokitto_settings.h"
 
 #define avrmax(a,b) ((a)>(b)?(a):(b))
@@ -46,103 +46,82 @@ using std::min;
 using std::max;
 #endif // DISABLEAVRMIN
 
-#define AB_JUMP 1024 // jump one 1-bit Arduboy screen forward to get next color bit
-#define GB_JUMP 504 // jump one 1-bit Gamebuino screen forward to get next color bit
-
 using namespace Pokitto;
 
-uint16_t prevdata=0; // if data does not change, do not adjust LCD bus lines
-
-
-#ifndef POK_EXT0_PWM_ENABLE
-#if POK_BOARDREV == 2
-    pwmout_t backlightpwm;
+#if !defined(POK_EXT0_PWM_ENABLE) && POK_BOARDREV == 2
+pwmout_t backlightpwm;
 #endif
-#endif
-
 
 volatile uint32_t *LCD = reinterpret_cast< volatile uint32_t * >(0xA0002188);
 
 /**************************************************************************/
 /*!
-    @brief  set up the 16-bit bus
+  @brief  set up the 16-bit bus
 */
 /**************************************************************************/
 
 static inline void setup_data_16(uint16_t data)
 {
-    //uint32_t p2=0;
-
-    //if (data != prevdata) {
-    //
-    //prevdata=data;
-
-    /** D0...D16 = P2_3 ... P2_18 **/
-    //p2 = data << 3;
-
-    //__disable_irq();    // Disable Interrupts
     SET_MASK_P2;
     LPC_GPIO_PORT->MPIN[2] = (data<<3); // write bits to port
     CLR_MASK_P2;
-    //__enable_irq();     // Enable Interrupts
-    //}
 }
 
 
 /**************************************************************************/
 /*!
-    @brief  Write a command to the lcd, 16-bit bus
+  @brief  Write a command to the lcd, 16-bit bus
 */
 /**************************************************************************/
 inline void write_command_16(uint16_t data)
 {
-   CLR_CS; // select lcd
-   CLR_CD; // clear CD = command
-   SET_RD; // RD high, do not read
-   setup_data_16(data); // function that inputs the data into the relevant bus lines
-   CLR_WR_SLOW;  // WR low
-   SET_WR;  // WR low, then high = write strobe
-   SET_CS; // de-select lcd
+    CLR_CS; // select lcd
+    CLR_CD; // clear CD = command
+    SET_RD; // RD high, do not read
+    setup_data_16(data); // function that inputs the data into the relevant bus lines
+    CLR_WR_SLOW;  // WR low
+    SET_WR;  // WR low, then high = write strobe
+    SET_CS; // de-select lcd
 }
 
 /**************************************************************************/
 /*!
-    @brief  Write data to the lcd, 16-bit bus
+  @brief  Write data to the lcd, 16-bit bus
 */
 /**************************************************************************/
 inline void write_data_16(uint16_t data)
 {
-   CLR_CS;
-   SET_CD;
-   SET_RD;
-   setup_data_16(data);
-   CLR_WR;
-   SET_WR;
-   SET_CS;
+    CLR_CS;
+    SET_CD;
+    SET_RD;
+    setup_data_16(data);
+    CLR_WR;
+    SET_WR;
+    SET_CS;
 }
 
 /**************************************************************************/
 /*!
-    @brief  Pump data to the lcd, 16-bit bus, public function
+  @brief  Pump data to the lcd, 16-bit bus, public function
 */
 /**************************************************************************/
 void Pokitto::pumpDRAMdata(uint16_t* data,uint16_t counter)
 {
-   while (counter--) {
-   CLR_CS;
-   SET_CD;
-   SET_RD;
-   setup_data_16(*data++);
-   CLR_WR;
-   SET_WR;
-   SET_CS;
-   }
+    while (counter--) {
+        CLR_CS;
+        SET_CD;
+        SET_RD;
+        setup_data_16(*data++);
+        CLR_WR;
+        SET_WR;
+        SET_CS;
+    }
 }
 
 
 /**************************************************************************/
 /*!
-    @brief  Point to a (x,y) location in the LCD DRAM
+  @brief  Point to a (x,y) location in the LCD DRAM
 */
 /**************************************************************************/
 static inline void setDRAMptr(uint8_t xptr, uint8_t yoffset)
@@ -157,7 +136,7 @@ static inline void setDRAMptr(uint8_t xptr, uint8_t yoffset)
 
 /**************************************************************************/
 /*!
-    @brief  Point to a (x,y) location in the LCD DRAM, public function
+  @brief  Point to a (x,y) location in the LCD DRAM, public function
 */
 /**************************************************************************/
 void Pokitto::setDRAMpoint(uint8_t xptr, uint8_t yoffset)
@@ -170,64 +149,80 @@ void Pokitto::setDRAMpoint(uint8_t xptr, uint8_t yoffset)
     CLR_CS_SET_CD_RD_WR;
 }
 
+/**************************************************************************/
+/*!
+  @brief  Get the LCD ready for a buffered-mode refresh
+*/
+/**************************************************************************/
+void Pokitto::lcdPrepareRefresh() {
+    write_command(0x03); write_data(0x1038);
+    write_command(0x20);  // Horizontal DRAM Address
+    write_data(0);  // 0
+    write_command(0x21);  // Vertical DRAM Address
+    write_data(0);  // 0
+    write_command(0x22); // write data to DRAM
+    CLR_CS_SET_CD_RD_WR;
+    SET_MASK_P2;
+}
+
 void Pokitto::initBacklight() {
-    #ifndef POK_EXT0_PWM_ENABLE
-        #if POK_BOARDREV == 2
-        LPC_SYSCON->SYSAHBCLKCTRL |= (1<<31);
-        LPC_SYSCON->PRESETCTRL |=  (1 << (0 + 9));
-        LPC_IOCON->PIO2_2 = (LPC_IOCON->PIO2_2 & ~(0x3FF)) | 0x3;     //set up pin for PWM use
-        LPC_SCT0->CONFIG |= ((0x3 << 17) | 0x01);
-        LPC_SCT0->CTRL |= (1 << 2) | (1 << 3);
+#ifndef POK_EXT0_PWM_ENABLE
+#if POK_BOARDREV == 2
+    LPC_SYSCON->SYSAHBCLKCTRL |= (1<<31);
+    LPC_SYSCON->PRESETCTRL |=  (1 << (0 + 9));
+    LPC_IOCON->PIO2_2 = (LPC_IOCON->PIO2_2 & ~(0x3FF)) | 0x3;     //set up pin for PWM use
+    LPC_SCT0->CONFIG |= ((0x3 << 17) | 0x01);
+    LPC_SCT0->CTRL |= (1 << 2) | (1 << 3);
 
-        LPC_SCT0->OUT1_SET = (1 << 0); // event 0
-        LPC_SCT0->OUT1_CLR = (1 << 1); // event 1
-        LPC_SCT0->EV0_CTRL  = (1 << 12);
-        LPC_SCT0->EV0_STATE = 0xFFFFFFFF;
-        LPC_SCT0->EV1_CTRL  = (1 << 12) | (1 << 0);
-        LPC_SCT0->EV1_STATE = 0xFFFFFFFF;
-        LPC_SCT0->MATCHREL0 = 20000;
+    LPC_SCT0->OUT1_SET = (1 << 0); // event 0
+    LPC_SCT0->OUT1_CLR = (1 << 1); // event 1
+    LPC_SCT0->EV0_CTRL  = (1 << 12);
+    LPC_SCT0->EV0_STATE = 0xFFFFFFFF;
+    LPC_SCT0->EV1_CTRL  = (1 << 12) | (1 << 0);
+    LPC_SCT0->EV1_STATE = 0xFFFFFFFF;
+    LPC_SCT0->MATCHREL0 = 20000;
 
-        setBacklight(POK_BACKLIGHT_INITIALVALUE);
-        #endif
-    #else
+    setBacklight(POK_BACKLIGHT_INITIALVALUE);
+#endif
+#else
     pin_function(P2_2,0);//set pin function back to 0
     LPC_GPIO_PORT->DIR[2] |= (1  << 2 );
     LPC_GPIO_PORT->SET[2] = 1 << 2; // full background light, smaller file size
-    #endif
+#endif
 
 }
 
 
 void Pokitto::setBacklight(uint8_t value) {
-    #ifndef POK_EXT0_PWM_ENABLE
+#ifndef POK_EXT0_PWM_ENABLE
     if (value>100)
         value = 100;
 
     LPC_SCT0->MATCHREL1 = (LPC_SCT0->MATCHREL0 * value)/100; 
     LPC_SCT0->CTRL &= ~(1 << 2);
-    #endif
+#endif
 }
 
 void Pokitto::lcdInit() {
-   initBacklight();
+    initBacklight();
 
-   SET_RESET;
-   wait_ms(10);
-   CLR_RESET;
-   wait_ms(10);
-   SET_RESET;
-   wait_ms(10);
-  //************* Start Initial Sequence **********//
+    SET_RESET;
+    wait_ms(10);
+    CLR_RESET;
+    wait_ms(10);
+    SET_RESET;
+    wait_ms(10);
+    //************* Start Initial Sequence **********//
     write_command(0x01); // driver output control, this also affects direction
     write_data(0x11C); // originally: 0x11C 100011100 SS,NL4,NL3,NL2
-                        // NL4...0 is the number of scan lines to drive the screen !!!
-                        // so 11100 is 1c = 220 lines, correct
-                        // test 1: 0x1C 11100 SS=0,NL4,NL3,NL2 -> no effect
-                        // test 2: 0x31C 1100011100 GS=1,SS=1,NL4,NL3,NL2 -> no effect
-                        // test 3: 0x51C 10100011100 SM=1,GS=0,SS=1,NL4,NL3,NL2 -> no effect
-                        // test 4: 0x71C SM=1,GS=1,SS=1,NL4,NL3,NL2
-                        // test 5: 0x
-                        // seems to have no effect... is this perhaps only for RGB mode ?
+    // NL4...0 is the number of scan lines to drive the screen !!!
+    // so 11100 is 1c = 220 lines, correct
+    // test 1: 0x1C 11100 SS=0,NL4,NL3,NL2 -> no effect
+    // test 2: 0x31C 1100011100 GS=1,SS=1,NL4,NL3,NL2 -> no effect
+    // test 3: 0x51C 10100011100 SM=1,GS=0,SS=1,NL4,NL3,NL2 -> no effect
+    // test 4: 0x71C SM=1,GS=1,SS=1,NL4,NL3,NL2
+    // test 5: 0x
+    // seems to have no effect... is this perhaps only for RGB mode ?
 
     write_command(0x02); // LCD driving control
     write_data(0x0100); // INV = 1
@@ -255,7 +250,7 @@ void Pokitto::lcdInit() {
     write_command(0x21);  // Vertical DRAM Address
     write_data(0x0000); // 0
 
- //*************Power On sequence ****************//
+    //*************Power On sequence ****************//
     write_command(0x10);
     write_data(0x0000);
 
@@ -342,31 +337,31 @@ void Pokitto::lcdInit() {
 }
 
 void Pokitto::lcdSleep(void){
-   write_command(0xFF);
-   write_data(0x0000);
+    write_command(0xFF);
+    write_data(0x0000);
 
-   write_command(0x07);
-   write_data(0x0000);
-   wait_ms(50);
-   write_command(0x10);// Enter Standby mode
-   write_data(0x0003);
-   wait_ms(200);
+    write_command(0x07);
+    write_data(0x0000);
+    wait_ms(50);
+    write_command(0x10);// Enter Standby mode
+    write_data(0x0003);
+    wait_ms(200);
 
 }
 
 void Pokitto::lcdWakeUp (void){
 
-   wait_ms(200);
-   write_command(0xFF);
-   write_data(0x0000);
+    wait_ms(200);
+    write_command(0xFF);
+    write_data(0x0000);
 
-   write_command(0x10);// Exit Sleep/ Standby mode
-   write_data(0x0000);
-   wait_ms(50);
-   write_command(0x07);
-   write_data(0x0117);
-   wait_ms(200);
-  }
+    write_command(0x10);// Exit Sleep/ Standby mode
+    write_data(0x0000);
+    wait_ms(50);
+    write_command(0x07);
+    write_data(0x0117);
+    wait_ms(200);
+}
 
 void Pokitto::lcdFillSurface(uint16_t c) {
     uint32_t i;
@@ -379,8 +374,8 @@ void Pokitto::lcdFillSurface(uint16_t c) {
     CLR_CS_SET_CD_RD_WR;
     for(i=0;i<220*176;i++)
     {
-    CLR_WR;
-    SET_WR;
+        CLR_WR;
+        SET_WR;
     }
 }
 
@@ -403,7 +398,7 @@ void Pokitto::lcdClear() {
 void Pokitto::lcdPixel(int16_t x, int16_t y, uint16_t color) {
     if ((x < 0) || (x >= POK_LCD_W) || (y < 0) || (y >= POK_LCD_H))
 	return;
-	write_command(0x20);  // Horizontal DRAM Address
+    write_command(0x20);  // Horizontal DRAM Address
     write_data(y);  // 0
     write_command(0x21);  // Vertical DRAM Address
     write_data(x);
@@ -414,59 +409,59 @@ void Pokitto::lcdPixel(int16_t x, int16_t y, uint16_t color) {
 }
 
 void Pokitto::setWindow(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2) {
-	write_command(0x37); write_data(x1);
-	write_command(0x36); write_data(x2);
-	write_command(0x39); write_data(y1);
-	write_command(0x38); write_data(y2);
-	write_command(0x20); write_data(x1);
-	write_command(0x21); write_data(y1);
+    write_command(0x37); write_data(x1);
+    write_command(0x36); write_data(x2);
+    write_command(0x39); write_data(y1);
+    write_command(0x38); write_data(y2);
+    write_command(0x20); write_data(x1);
+    write_command(0x21); write_data(y1);
 }
 
 void Pokitto::lcdTile(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t* gfx){
-	int width=x1-x0;
-	int height=y1-y0;
-	if (x0 > POK_LCD_W) return;
-	if (y0 > POK_LCD_H) return;
-	if (x0 < 0) x0=0;
-	if (y0 < 0) y0=0;
+    int width=x1-x0;
+    int height=y1-y0;
+    if (x0 > POK_LCD_W) return;
+    if (y0 > POK_LCD_H) return;
+    if (x0 < 0) x0=0;
+    if (y0 < 0) y0=0;
 
-	setWindow(y0, x0, y1-1, x1-1);
+    setWindow(y0, x0, y1-1, x1-1);
     write_command(0x22);
 
     for (int x=0; x<=width*height-1;x++) {
         write_data(gfx[x]);
     }
-	setWindow(0, 0, 175, 219);
+    setWindow(0, 0, 175, 219);
 }
 
 
 void Pokitto::lcdRectangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color) {
-	int16_t temp;
-	if (x0>x1) {temp=x0;x0=x1;x1=temp;}
-	if (y0>y1) {temp=y0;y0=y1;y1=temp;}
-	if (x0 > POK_LCD_W) return;
-	if (y0 > POK_LCD_H) return;
-	if (x1 > POK_LCD_W) x1=POK_LCD_W;
-	if (y1 > POK_LCD_H) y1=POK_LCD_H;
-	if (x0 < 0) x0=0;
-	if (y0 < 0) y0=0;
+    int16_t temp;
+    if (x0>x1) {temp=x0;x0=x1;x1=temp;}
+    if (y0>y1) {temp=y0;y0=y1;y1=temp;}
+    if (x0 > POK_LCD_W) return;
+    if (y0 > POK_LCD_H) return;
+    if (x1 > POK_LCD_W) x1=POK_LCD_W;
+    if (y1 > POK_LCD_H) y1=POK_LCD_H;
+    if (x0 < 0) x0=0;
+    if (y0 < 0) y0=0;
 
-	int16_t x,y;
-	for (x=x0; x<=x1;x++) {
-		write_command(0x20);  // Horizontal DRAM Address (=y on pokitto screen)
-		write_data(y0);
-		write_command(0x21);  // Vertical DRAM Address (=x on pokitto screen)
-		write_data(x);
-		write_command(0x22); // write data to DRAM
+    int16_t x,y;
+    for (x=x0; x<=x1;x++) {
+        write_command(0x20);  // Horizontal DRAM Address (=y on pokitto screen)
+        write_data(y0);
+        write_command(0x21);  // Vertical DRAM Address (=x on pokitto screen)
+        write_data(x);
+        write_command(0x22); // write data to DRAM
 
-		CLR_CS_SET_CD_RD_WR; // go to vram write mode
+        CLR_CS_SET_CD_RD_WR; // go to vram write mode
 
 
-		for (y=y0; y<y1;y++) {
-				setup_data_16(color); // setup the data (flat color = no change between pixels)
-				CLR_WR;SET_WR; //CLR_WR;SET_WR;//toggle writeline, pokitto screen writes a column up to down
-		}
-	}
+        for (y=y0; y<y1;y++) {
+            setup_data_16(color); // setup the data (flat color = no change between pixels)
+            CLR_WR;SET_WR; //CLR_WR;SET_WR;//toggle writeline, pokitto screen writes a column up to down
+        }
+    }
 }
 
 /***
@@ -481,2052 +476,153 @@ void Pokitto::lcdRectangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint1
  * @param updRectW The update rect.
  * @param updRectH The update rect.
  * @param paletteptr The screen palette.
-*/
-
-
-#define MODE1_LOOP					\
-  "	adds %[t], %[palette]"			"\n"	\
-  "	ldm %[t], {%[t], %[x]}"			"\n"	\
-  "	str %[t], [%[LCD], 0]"			"\n"	\
-  "	movs %[t], 252"	"\n"				\
-  "	str %[WRBit], [%[LCD], %[t]]"   	"\n"	\
-  "	str %[WRBit], [%[LCD], 124]"		"\n"	\
-  "	str %[x], [%[LCD], 0]"			"\n"	\
-  "	str %[WRBit], [%[LCD], %[t]]"   	"\n"	\
-  "	movs %[t], 0x0F"			"\n"	\
-  "	ands %[t], %[t], %[c]"			"\n"	\
-  "	str %[WRBit], [%[LCD], 124]"		"\n"	\
-							\
-  "	lsls %[t], 3"				"\n"    \
-  "	adds %[t], %[palette]"			"\n"	\
-  "	ldm %[t], {%[t], %[x]}"			"\n"	\
-  "	str %[t], [%[LCD], 0]"			"\n"	\
-  "	movs %[t], 252"	"\n"				\
-  "	str %[WRBit], [%[LCD], %[t]]"   	"\n"	\
-  "	str %[WRBit], [%[LCD], 124]"		"\n"	\
-  "	str %[x], [%[LCD], 0]"			"\n"	\
-  "	str %[WRBit], [%[LCD], %[t]]"   	"\n"	\
-  "	lsrs %[c], 8"				"\n"	\
-  "	movs %[t], 0xF0"			"\n"	\
-  "	ands %[t], %[t], %[c]"			"\n"	\
-  "	lsrs %[t], %[t], 1"			"\n"	\
-  "	str %[WRBit], [%[LCD], 124]"		"\n"
-
-
-void Pokitto::lcdRefreshMode1(uint8_t * scrbuf, uint8_t updRectX, uint8_t updRectY, uint8_t updRectW, uint8_t updRectH, uint16_t* paletteptr) {
-
-
-#ifdef XPERIMENTAL
-//#define __ARMCC_VERSION 1
-#endif
-
-#ifndef __ARMCC_VERSION
-
-  write_command(0x03); write_data(0x1038);
-  write_command(0x20);  // Horizontal DRAM Address
-  write_data(0);
-  write_command(0x21);  // Vertical DRAM Address
-  write_data(0);
-  write_command(0x22); // write data to DRAM
-  CLR_CS_SET_CD_RD_WR;
-
-  uint8_t *end=&scrbuf[POK_SCREENBUFFERSIZE>>1]+4;
-
-  volatile uint32_t palette[32];
-  for( uint32_t i=0; i<16; ++i ){
-    palette[(i<<1)+1] = static_cast<uint32_t>(paletteptr[i&3 ]) << 3;
-    palette[(i<<1)  ] = static_cast<uint32_t>(paletteptr[i>>2]) << 3;
-  }
-
-  SET_MASK_P2;
-
-  uint32_t c, WRBit = 1<<12;
-
-  register uint32_t x asm("r2");
-  register uint32_t t asm("r1");
-
-  asm volatile(
-
-	 ".syntax unified"         		"\n"
-	 "ldm %[scrbuf]!, {%[c]}"		"\n" // load 4 bytes (16 pixels)
-	 "movs %[t], 0xF0"			"\n"
-	 "ands %[t], %[t], %[c]"		"\n"
-	 "lsrs %[t], %[t], 1"			"\n"
-	 "mode1Loop%=:" 			"\n"
-	 MODE1_LOOP
-	 MODE1_LOOP
-	 MODE1_LOOP
-	 "	adds %[t], %[palette]"			"\n"
-	 "	ldm %[t], {%[t], %[x]}"			"\n"
-	 "	str %[t], [%[LCD], 0]"			"\n"
-	 "	movs %[t], 252"	"\n"
-	 "	str %[WRBit], [%[LCD], %[t]]"   	"\n"
-	 "	str %[WRBit], [%[LCD], 124]"		"\n"
-	 "	str %[x], [%[LCD], 0]"			"\n"
-	 "	str %[WRBit], [%[LCD], %[t]]"   	"\n"
-	 "	movs %[t], 0x0F"			"\n"
-	 "	ands %[t], %[t], %[c]"			"\n"
-	 "	str %[WRBit], [%[LCD], 124]"		"\n"
-
-	 "	lsls %[t], 3"				"\n"
-	 "	adds %[t], %[palette]"			"\n"
-	 "	ldm %[t], {%[t], %[x]}"			"\n"
-	 "	str %[t], [%[LCD], 0]"			"\n"
-	 "	movs %[t], 252"	"\n"
-	 "	str %[WRBit], [%[LCD], %[t]]"   	"\n"
-	 "	str %[WRBit], [%[LCD], 124]"		"\n"
-	 "	str %[x], [%[LCD], 0]"			"\n"
-	 "	str %[WRBit], [%[LCD], %[t]]"   	"\n"
-
-	 "	ldm %[scrbuf]!, {%[c]}"		"\n" // load next 4 bytes
-	 "	movs %[t], 0xF0"		"\n"
-	 "	ands %[t], %[t], %[c]"		"\n"
-	 "	lsrs %[t], %[t], 1"		"\n"
-	 "	str %[WRBit], [%[LCD], 124]"		"\n"
-
-	 "cmp %[end], %[scrbuf]"            	"\n"
-	 "bne mode1Loop%="       		"\n" // if scrbuf < end, loop
-
-	 : // outputs
-	   [c]"+l" (c),
-	   [t]"+l" (t),
-	   [end]"+h" (end),
-	   [scrbuf]"+l" (scrbuf),
-	   [WRBit]"+l" (WRBit),
-	   [x]"+l" (x)
-
-	 : // inputs
-	   [LCD]"l" (0xA0002188),
-	   [palette]"l" (palette)
-
-	 : // clobbers
-	   "cc"
-	       );
-
-
+ */
+void Pokitto::lcdRefreshMode1(const uint8_t *scrbuf, const uint16_t *paletteptr) {
+    volatile uint32_t palette[32];
+    for( uint32_t i=0; i<16; ++i ){
+        palette[(i<<1)+1] = static_cast<uint32_t>(paletteptr[i&3 ]) << 3;
+        palette[(i<<1)  ] = static_cast<uint32_t>(paletteptr[i>>2]) << 3;
+    }
+    
+#if POK_PERSISTENCE > 0
+    updateMode1Clear(palette, scrbuf, POK_CLEAR_SCREEN);
 #else
-    uint16_t x,y,xptr;
-    uint16_t scanline[4][176]; // read 4 half-nibbles = 4 pixels at a time
-    uint8_t *d, yoffset=0;
-
-    // If not the full screen is updated, check the validity of the update rect.
-    if ( updRectX != 0 || updRectY != 0 ||updRectW != LCDWIDTH ||updRectH != LCDHEIGHT ) {
-        uint8_t org_screenx = updRectX;
-        updRectX &= 0xfc; // Make the value dividable by 4.
-        updRectW += org_screenx - updRectX;
-        updRectW = (updRectW + 3) & 0xfc; // Make the value dividable by 4, round up.
-
-        uint8_t org_screeny = updRectY;
-        updRectY &= 0xfc; // Make the value dividable by 4.
-        updRectH += org_screeny - updRectY;
-        updRectH = (updRectH + 7) & 0xf8; // Make the value dividable by 8 (because of loop unroll optimization), round up.
-    }
-
-
-    #ifdef PROJ_SHOW_FPS_COUNTER
-    xptr = 8;
-    setDRAMptr(8, 0);
-    #else
-    xptr = 0;
-    setDRAMptr(0, 0);
-    #endif
-
-    for (x=updRectX; x<updRectX+updRectW; x+=4) {
-        d = scrbuf+(x>>2);// point to beginning of line in data
-
-        /** find colours in one scanline **/
-        uint8_t s=0;
-        d += (updRectY * 220/4);
-        for (y=updRectY; y<updRectY+updRectH; y++) {
-            uint8_t tdata = *d;
-            uint8_t t4 = tdata & 0x03; tdata >>= 2;// lowest half-nibble
-            uint8_t t3 = tdata & 0x03; tdata >>= 2;// second lowest half-nibble
-            uint8_t t2 = tdata & 0x03; tdata >>= 2;// second highest half-nibble
-            uint8_t t = tdata & 0x03;// highest half-nibble
-
-            /** put nibble values in the scanlines **/
-            scanline[0][y] = paletteptr[t];
-            scanline[1][y] = paletteptr[t2];
-            scanline[2][y] = paletteptr[t3];
-            scanline[3][y] = paletteptr[t4];
-
-            d += 220/4; // jump to read byte directly below in screenbuffer
-        }
-
-        #ifdef PROJ_SHOW_FPS_COUNTER
-        if (x>=8 ) {
-        #else
-        {
-
-        #endif
-
-            // Draw 8 vertical pixels at a time for performance reasons
-            setDRAMptr(x, updRectY);
-            for (uint8_t s=updRectY; s<updRectY+updRectH;) {
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-            }
-            setDRAMptr(x+1, updRectY);
-            for (uint8_t s=updRectY; s<updRectY+updRectH;) {
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-            }
-            setDRAMptr(x+2, updRectY);
-            for (uint8_t s=updRectY; s<updRectY+updRectH;) {
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-            }
-            setDRAMptr(x+3, updRectY);
-            for (uint8_t s=updRectY; s<updRectY+updRectH;) {
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-            }
-        }
-    }
+    updateMode1(palette, scrbuf);
 #endif
-
-    #ifdef POK_SIM
-    simulator.refreshDisplay();
-    #endif
 }
 
-// Copy sprite pixels to the scanline
-#define SPRITE_2BPP_INNER_LOOP(n)\
-\
-    /* If the sprite is enabled and contained in this vertical scanline, copy 4 pixels. */\
-    if (sprScanlineAddr[(n)] &&\
-        y >= sprites[(n)].y && y < sprites[(n)].y + sprites[(n)].h ) {\
-\
-        int16_t sprx = sprites[(n)].x;\
-        uint16_t s_data16b = 0;  /* sprite data, 2 bytes */\
-\
-        /* Get pixel block, 4 or 8 pixels horizontally. Use the predefined bitshift mode. */\
-        /* Note:it is cheapest to compare to 0 first. */\
-        if (sprScanlineBitshiftMode[(n)] == BITSHIFT_MODE_MIDDLE_BYTE) {\
-            s_data16b = *(sprScanlineAddr[(n)]);\
-            uint16_t leftByte = *(sprScanlineAddr[(n)]-1);\
-            s_data16b = (leftByte << 8) | s_data16b;\
-        }\
-        else if (sprScanlineBitshiftMode[(n)] == BITSHIFT_MODE_FIRST_BYTE) {\
-            s_data16b = *(sprScanlineAddr[(n)]);\
-        }\
-        else { /* BITSHIFT_MODE_LAST_BYTE */\
-            uint16_t leftByte = *(sprScanlineAddr[(n)]-1);\
-            s_data16b = (leftByte << 8) | s_data16b;\
-        }\
-\
-        /* Shift sprite pixels according to sprite x. After shifting we have only 4 pixels. */\
-        uint8_t shiftRight = (sprx&0x3) << 1;\
-        s_data16b = (s_data16b >> shiftRight);\
-\
-        /* Get individual pixels */\
-        uint8_t s_t4 = s_data16b & 0x03; s_data16b >>= 2; /* lowest half-nibble */\
-        uint8_t s_t3 = s_data16b & 0x03; s_data16b >>= 2; /* second lowest half-nibble */\
-        uint8_t s_t2 = s_data16b & 0x03; s_data16b >>= 2; /* second highest half-nibble */\
-        uint8_t s_t1 = s_data16b & 0x03;                  /* highest half-nibble */\
-\
-        /* Store pixels as 16-bit colors from the palette */\
-        if (s_t4 != transparentColor) p4 = sprites[(n)].palette[s_t4];\
-        if (s_t3 != transparentColor) p3 = sprites[(n)].palette[s_t3];\
-        if (s_t2 != transparentColor) p2 = sprites[(n)].palette[s_t2];\
-        if (s_t1 != transparentColor) p = sprites[(n)].palette[s_t1];\
-\
-        /* Advance scanline address */\
-        sprScanlineAddr[(n)] += (sprites[(n)].w >> 2);\
-    }
-
-// Loop unrolling macros
-#define UNROLLED_LOOP_1() SPRITE_2BPP_INNER_LOOP(0)
-#define UNROLLED_LOOP_2() UNROLLED_LOOP_1() SPRITE_2BPP_INNER_LOOP(1)
-#define UNROLLED_LOOP_3() UNROLLED_LOOP_2() SPRITE_2BPP_INNER_LOOP(2)
-#define UNROLLED_LOOP_4() UNROLLED_LOOP_3() SPRITE_2BPP_INNER_LOOP(3)
-#define UNROLLED_LOOP_5() UNROLLED_LOOP_4() SPRITE_2BPP_INNER_LOOP(4)
-#define UNROLLED_LOOP_6() UNROLLED_LOOP_5() SPRITE_2BPP_INNER_LOOP(5)
-#define UNROLLED_LOOP_7() UNROLLED_LOOP_6() SPRITE_2BPP_INNER_LOOP(6)
-#define UNROLLED_LOOP_8() UNROLLED_LOOP_7() SPRITE_2BPP_INNER_LOOP(7)
-#define UNROLLED_LOOP_9() UNROLLED_LOOP_8() SPRITE_2BPP_INNER_LOOP(8)
-#define UNROLLED_LOOP_10() UNROLLED_LOOP_9() SPRITE_2BPP_INNER_LOOP(9)
-#define UNROLLED_LOOP_11() UNROLLED_LOOP_10() SPRITE_2BPP_INNER_LOOP(10)
-#define UNROLLED_LOOP_12() UNROLLED_LOOP_11() SPRITE_2BPP_INNER_LOOP(11)
-#define UNROLLED_LOOP_13() UNROLLED_LOOP_12() SPRITE_2BPP_INNER_LOOP(12)
-#define UNROLLED_LOOP_14() UNROLLED_LOOP_13() SPRITE_2BPP_INNER_LOOP(13)
-#define UNROLLED_LOOP_15() UNROLLED_LOOP_14() SPRITE_2BPP_INNER_LOOP(14)
-#define UNROLLED_LOOP_16() UNROLLED_LOOP_15() SPRITE_2BPP_INNER_LOOP(15)
-#define UNROLLED_LOOP_N_(n) UNROLLED_LOOP_##n()
-#define UNROLLED_LOOP_N(n) UNROLLED_LOOP_N_(n)
-
-/***
- * Update the screen buffer of 220x176 pixels, 4 colors and free size 4 color sprites to LCD.
- *
- * The update rect is used for drawing only part of the screen buffer to LCD. Because of speed optimizations, the
- * x, y, and width of the update rect must be dividable by 4 pixels, and the height must be dividable by 8 pixels.
- * Note: The update rect is currently used for 220x176, 4 colors, screen mode only.
- * If drawSpritesOnly=true, only sprites are fully updated to LCD. However, the dirty rect of the screen buffer is
- * drawn behind the sprite current and previous location.
- * Note: Sprite is enabled if sprite.bitmapData is not NULL. Also all enabled sprites must be at the beginning of
- * the sprites array. No gaps are allowed in the array.
- * @param scrbuf The screen buffer.
- * @param updRectX The update rect.
- * @param updRectY The update rect.
- * @param updRectW The update rect.
- * @param updRectH The update rect.
- * @param paletteptr The screen palette.
- * @param sprites The sprite array.
- * @param drawSpritesOnly True, if only sprites are drawn. False, if both sprites and the screen buffer are drawn.
-*/
-void Pokitto::lcdRefreshMode1Spr(
-    uint8_t * scrbuf, uint8_t updRectX, uint8_t updRectY, uint8_t updRectW, uint8_t updRectH, uint16_t* paletteptr,
-    SpriteInfo* sprites, bool drawSpritesOnly) {
-
-    // In direct mode draw only sprites and their dirty rects. Return now if there are no sprites
-    if (drawSpritesOnly && (sprites == NULL || sprites[0].bitmapData == NULL))
-        return;
-
-    uint16_t x,y;
-    uint16_t scanline[4][176]; // read 4 half-nibbles (= 4 pixels) at a time
-    const uint8_t transparentColor = 0;  // fixed palette index 0 for transparency
-
-    // If not the full screen is updated, check the validity of the update rect.
-    if ( updRectX != 0 || updRectY != 0 ||updRectW != LCDWIDTH ||updRectH != LCDHEIGHT ) {
-        uint8_t org_screenx = updRectX;
-        updRectX &= 0xfc; // Make the value dividable by 4.
-        updRectW += org_screenx - updRectX;
-        updRectW = (updRectW + 3) & 0xfc; // Make the value dividable by 4, round up.
-
-        uint8_t org_screeny = updRectY;
-        updRectY &= 0xfc; // Make the value dividable by 4.
-        updRectH += org_screeny - updRectY;
-        updRectH = (updRectH + 7) & 0xf8; // Make the value dividable by 8 (because of loop unroll optimization), round up.
-    }
-
-    // Calculate the current  amount of sprites
-    // Note: Sprites must be taken into use from index 0 upwards, because the first sprite with bitmapData==NULL is considered as the last sprite
-    uint8_t spriteCount = 0;
-    if (sprites != NULL)
-        for (;sprites[spriteCount].bitmapData != NULL && spriteCount < SPRITE_COUNT; spriteCount++);
-
-    // If drawing the screen buffer, set the start pos to LCD commands only here.
-    #ifdef PROJ_SHOW_FPS_COUNTER
-    if (!drawSpritesOnly) setDRAMptr(8, 0);
-    #else
-    if (!drawSpritesOnly) setDRAMptr(0, 0);
-    #endif
-
-    //*** GO THROUGH EACH VERTICAL GROUP OF 4 SCANLINES.***
-
-    for (x=0; x<LCDWIDTH; x+=4) {
-
-        uint8_t *screenBufScanlineAddr = scrbuf + (x>>2);// point to beginning of line in data
-
-        /*Prepare scanline start address for sprites that are visible in this vertical scanline. Sprite width cannot exceed the screen width*/
-        uint8_t *sprScanlineAddr[SPRITE_COUNT];  // Sprite start address for the scanline
-        uint8_t sprScanlineBitshiftMode[SPRITE_COUNT];  // Sprite bitshift mode for the scanline
-        const uint8_t BITSHIFT_MODE_MIDDLE_BYTE = 0;
-        const uint8_t BITSHIFT_MODE_FIRST_BYTE = 1;
-        const uint8_t BITSHIFT_MODE_LAST_BYTE = 2;
-        uint8_t scanlineMinY = 255; // Init to uninitialized value. Do not draw by default.
-        uint8_t scanlineMaxY = 0; // Init to uninitialized value. Do not draw by default.
-
-        //*** CALCULATE DIRTY RECTS AND RESOLVE WHICH SPRITES BELONG TO THIS SCANLINE GROUP ***
-
-        if (sprites != NULL) {
-
-            // Check all the sprites for this scanline. That is used for handling the given update rect
-            // Note that the last round is when (sprindex == spriteCount). That is used to add the screen buffer
-            // update rect to the dirty rect.
-            for (int sprindex = 0; sprindex <= spriteCount; sprindex++) {
-
-                int16_t sprx, spry, sprOldX, sprOldY;
-                uint8_t sprw, sprh;
-                bool isCurrentSpriteOutOfScreen = false;
-                bool isOldSpriteOutOfScreen = false;
-
-                if (sprindex < spriteCount) {
-
-                    sprx = sprites[sprindex].x;
-                    spry = sprites[sprindex].y;
-                    sprw = sprites[sprindex].w;
-                    sprh = sprites[sprindex].h;
-                    sprOldX = sprites[sprindex].oldx;
-                    sprOldY = sprites[sprindex].oldy;
-               }
-
-                // Handle the screen buffer update rect after all sprites
-                else if(!drawSpritesOnly){
-
-                    sprx = updRectX;
-                    spry = updRectY;
-                    sprw = updRectW;
-                    sprh = updRectH;
-                    sprOldX = updRectX;
-                    sprOldY = updRectY;
-                    isCurrentSpriteOutOfScreen = false;
-                    isOldSpriteOutOfScreen = false;
-                }
-
-                // Check for out-of-screen
-                if (sprx >= LCDWIDTH || spry >= LCDHEIGHT)
-                    isCurrentSpriteOutOfScreen = true;
-                if (sprOldX >= LCDWIDTH || sprOldY >= LCDHEIGHT)
-                    isOldSpriteOutOfScreen = true;
-
-                // Skip if current and old sprites are out-of-screen
-                if (isCurrentSpriteOutOfScreen && isOldSpriteOutOfScreen)
-                    continue;
-
-                // Detect the dirty rect x-span by combining the previous and current sprite position.
-                int16_t sprDirtyXMin = avrmin(sprx, sprOldX);
-                int16_t sprDirtyXMax = avrmax(sprx, sprOldX);
-                if (isCurrentSpriteOutOfScreen)
-                    sprDirtyXMax = sprOldX;
-                if (isOldSpriteOutOfScreen)
-                    sprDirtyXMax = sprx;
-
-                // Is current x inside the sprite combined dirty rect ?
-                int16_t sprDirtyXMaxEnd = sprDirtyXMax + sprw - 1 + 4; // Add 4 pixels to dirty rect width (needed?)
-                if (sprDirtyXMin <= x+3 && x <= sprDirtyXMaxEnd) {
-
-                    // *** COMBINE DIRTY RECTS FOR THIS SCANLINE GROUP ***
-
-                    // Dirty rect
-                    int sprDirtyYMin = avrmin(spry, sprOldY);
-                    sprDirtyYMin = avrmax((int)sprDirtyYMin, 0);
-                    int sprDirtyYMax = avrmax(spry, sprOldY);
-                    if (isCurrentSpriteOutOfScreen)
-                        sprDirtyYMax = sprOldY;
-                    if (isOldSpriteOutOfScreen)
-                        sprDirtyYMax = spry;
-                    int sprDirtyYMaxEnd = sprDirtyYMax + sprh - 1;
-                    sprDirtyYMaxEnd = avrmin(sprDirtyYMaxEnd, LCDHEIGHT - 1);  // Should use LCDHEIGHT instead of screenH? Same with other screen* ?
-
-                    // Get the scanline min and max y values for drawing
-                    if (sprDirtyYMin < scanlineMinY)
-                        scanlineMinY = sprDirtyYMin;
-                    if (sprDirtyYMaxEnd > scanlineMaxY)
-                        scanlineMaxY = sprDirtyYMaxEnd;
-
-                   // *** PREPARE SPRITE FOR DRAWING ***
-
-                   // Check if the sprite should be active for this vertical scanline group.
-                    if (sprindex < spriteCount &&  // not for update rect
-                        !isCurrentSpriteOutOfScreen && //out-of-screen
-                        sprx <= x+3 && x < sprx + sprw) { // note: cover group of 4 pixels of the scanline (x+3)
-
-                        // Find the byte number in the sprite data
-                        int16_t byteNum = ((x+3) - sprx)>>2;
-
-                        // Get the start addres of the spite data in this scanline.
-                        sprScanlineAddr[sprindex] = const_cast<uint8_t*>(sprites[sprindex].bitmapData + byteNum);
-
-                        // If the sprite goes over the top, it must be clipped from the top.
-                        if(spry < 0)
-                            sprScanlineAddr[sprindex] += (-spry) * (sprw >> 2);
-
-                        // Select the bitshift mode for the blit algorithm
-                        if (byteNum == 0)
-                            sprScanlineBitshiftMode[sprindex] = BITSHIFT_MODE_FIRST_BYTE;
-                        else if (byteNum >= (sprw >> 2))
-                            sprScanlineBitshiftMode[sprindex] = BITSHIFT_MODE_LAST_BYTE;
-                        else
-                            sprScanlineBitshiftMode[sprindex] = BITSHIFT_MODE_MIDDLE_BYTE;
-                    }
-                    else
-                        sprScanlineAddr[sprindex] = NULL;  // Deactive sprite for this scanline
-                }
-                else
-                    sprScanlineAddr[sprindex] = NULL;  // Deactive sprite for this scanline
-            }
-        }
-
-        // *** ADJUST THE SCANLINE GROUP HEIGHT ***
-
-        // The height must dividable by 8. That is needed because later we copy 8 pixels at a time to the LCD.
-        if (scanlineMaxY - scanlineMinY + 1 > 0) {
-            uint8_t scanlineH = scanlineMaxY - scanlineMinY + 1;
-            uint8_t addW = 8 - (scanlineH & 0x7);
-
-            // if height is not dividable by 8, make it be.
-            if (addW != 0) {
-                if (scanlineMinY > addW )
-                    scanlineMinY -= addW;
-                else if( scanlineMaxY + addW < updRectY+updRectH)
-                    scanlineMaxY += addW;
-                else {
-                    // Draw full height scanline
-                    scanlineMinY = updRectY;
-                    scanlineMaxY = updRectY+updRectH-1;
-                }
-            }
-        }
-
-        // *** COMBINE THE SCANLINE GROUP OF THE SCREEN BUFFER AND ALL SPRITES ***
-
-        // Find colours in this group of 4 scanlines
-        screenBufScanlineAddr += (scanlineMinY * 220/4);
-        for (y=scanlineMinY; y<=scanlineMaxY; y++)
-        {
-            // get the screen buffer data first
-            uint8_t tdata = *screenBufScanlineAddr;
-            uint8_t t4 = tdata & 0x03; tdata >>= 2;// lowest half-nibble
-            uint8_t t3 = tdata & 0x03; tdata >>= 2;// second lowest half-nibble
-            uint8_t t2 = tdata & 0x03; tdata >>= 2;// second highest half-nibble
-            uint8_t t = tdata & 0x03;// highest half-nibble
-
-            // Convert to 16-bit colors in palette
-            uint16_t p = paletteptr[t];
-            uint16_t p2 = paletteptr[t2];
-            uint16_t p3 = paletteptr[t3];
-            uint16_t p4 = paletteptr[t4];
-
-            #if 0
-            // Dirty rect visual test
-            p = COLOR_BLUE >> (Core::frameCount % 5);
-            p2 = COLOR_BLUE >> (Core::frameCount % 5);
-            p3 = COLOR_BLUE >> (Core::frameCount % 5);
-            p4 = COLOR_BLUE >> (Core::frameCount % 5);
-            #endif
-
-            // Add active sprite pixels
-            if (sprites != NULL) {
-
-                // Use loop unrolling for speed optimization
-                UNROLLED_LOOP_N(SPRITE_COUNT)
-            }
-
-            // put the result nibble values in the scanline
-            scanline[0][y] = p;
-            scanline[1][y] = p2;
-            scanline[2][y] = p3;
-            scanline[3][y] = p4;
-
-            screenBufScanlineAddr += 220>>2; // jump to read byte directly below in screenbuffer
-        }
-
-        // *** DRAW THE SCANLINE GROUP TO LCD
-
-#ifdef PROJ_SHOW_FPS_COUNTER
-        if (x>=8 && scanlineMaxY - scanlineMinY +1 > 0) {
+void Pokitto::lcdRefreshMode2(const uint8_t* scrbuf, const uint16_t* paletteptr ) {
+#if POK_PERSISTENCE > 0
+    updateMode2Clear(paletteptr, scrbuf, POK_CLEAR_SCREEN);
 #else
-        if (scanlineMaxY - scanlineMinY +1 > 0) {
+    updateMode2(paletteptr, scrbuf);
 #endif
-            // Draw 8 vertical pixels at a time for performance reasons
-
-            setDRAMptr(x, scanlineMinY);
-            for (uint8_t s=scanlineMinY;s<=scanlineMaxY;) {
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-            }
-
-            setDRAMptr(x+1, scanlineMinY);
-            for (uint8_t s=scanlineMinY;s<=scanlineMaxY;) {
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-            }
-
-            setDRAMptr(x+2, scanlineMinY);
-            for (uint8_t s=scanlineMinY;s<=scanlineMaxY;) {
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-            }
-
-            setDRAMptr(x+3, scanlineMinY);
-            for (uint8_t s=scanlineMinY;s<=scanlineMaxY;) {
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-                setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-            }
-        }
-    }
-
-    // Update old x and y for the sprites
-    if (sprites != NULL) {
-        for (int sprindex = 0; sprindex < spriteCount; sprindex++) {
-            sprites[sprindex].oldx = sprites[sprindex].x;
-            sprites[sprindex].oldy = sprites[sprindex].y;
-        }
-    }
-
-    #ifdef POK_SIM
-    simulator.refreshDisplay();
-    #endif
 }
 
-
-#define MODE2_INNER_LOOP_B				\
-  "	ldm %[scanline]!, {%[c]}"   "\n"		\
-	       "	str %[c], [%[LCD], 0]"    "\n"	\
-	       "	str %[t], [%[LCD], 124]"  "\n"	\
-	       "	movs %[c], 252"   "\n"		\
-	       "	str %[t], [%[LCD], %[c]]" "\n"	\
-	       "	str %[t], [%[LCD], 124]"  "\n"	\
-	       "	subs %[x], 1"             "\n"	\
-	       "	str %[t], [%[LCD], %[c]]" "\n"	\
-
-
-void Pokitto::lcdRefreshMode2(uint8_t * scrbuf, uint16_t* paletteptr ) {
-  uint32_t x,y,byte,c,t=1<<12;
-  uint32_t scanline[110];
-
-  write_command(0x03); write_data(0x1038);
-  write_command(0x20);  // Horizontal DRAM Address
-
-  #ifdef PROJ_SHOW_FPS_COUNTER
-  y=4;
-  write_data(8);
-  #else
-  write_data(0);  // 0
-  #endif
-
-  write_command(0x21);  // Vertical DRAM Address
-
-#ifndef __ARMCC_VERSION
-  write_data(1); // still has pixel 0 bug
-  write_command(0x22); // write data to DRAM
-  CLR_CS_SET_CD_RD_WR;
-  SET_MASK_P2;
-
-  asm volatile(
-	 ".syntax unified"         "\n"
-
-	 "mov r10, %[scanline]"    "\n"
-	 "mov r11, %[t]"           "\n"
-
-	 "mode2OuterLoop:"        "\n"
-
-	 "movs %[x], 110"          "\n"
-	 "mode2InnerLoopA:"
-
-
-	 "	ldrb %[byte], [%[scrbuf],0]"   "\n" // Load the byte from the 4-bit screen buffer
-	 "	lsrs %[c], %[byte], 4"    "\n"      // c = byte >> 4 // Get the higher nibble
-
-	 "	movs %[t], 15" "\n"
-	 "	ands %[byte], %[t]"    "\n"         // byte = byte & 0xF // Get the lower nibble
-
-	 "	lsls %[c], 1"             "\n"      // c = c << 1
-	 "	ldrh %[t], [%[paletteptr], %[c]]"      "\n"  // t = paletteptr[c] // Load the actual color value from the palette
-	 "	lsls %[t], %[t], 3"       "\n"      // t = t << 3
-	 "	str %[t], [%[LCD], 0]"    "\n"      // LCD + 0 = t  // Copy color to LCD
-	 "	mov %[c], r11" "\n"                 // c = 4096
-	 "	str %[c], [%[LCD], 124]"  "\n"      // CLR
-	 "	stm %[scanline]!, {%[t]}" "\n"      // scanline = t // Store pixel to scanline
-	 "	movs %[t], 252"   "\n"
-	 "	str %[c], [%[LCD], %[t]]" "\n"      // SET
-	 "	str %[c], [%[LCD], 124]"  "\n"      // CLR
-	 "	lsls %[byte], %[byte], 1"             "\n"  // byte = byte << 1
-	 "	str %[c], [%[LCD], %[t]]" "\n"      // SET
-
-	 "	ldrh %[t], [%[paletteptr], %[byte]]"      "\n"  // t = paletteptr[byte] // Load the actual color value from the palette
-	 "	lsls %[t], %[t], 3"       "\n"
-	 "	str %[t], [%[LCD], 0]"    "\n"      // LCD + 0 = t  // Copy color to LCD
-	 "	mov %[c], r11" "\n"                 // c = 4096
-	 "	str %[c], [%[LCD], 124]"  "\n"      // CLR
-	 "	stm %[scanline]!, {%[t]}" "\n"      // scanline = t // Store pixel to scanline
-	 "	movs %[t], 252"   "\n"
-	 "	str %[c], [%[LCD], %[t]]" "\n"      // SET
-	 "	str %[c], [%[LCD], 124]"  "\n"      // CLR
-	 "	adds %[scrbuf], %[scrbuf], 1" "\n"  // scrbuf += 1 // Points to the next byte in the 4-bit screen buffer
-	 "	str %[c], [%[LCD], %[t]]" "\n"      // SET
-
-	 "	subs %[x], 2"          "\n"         // x -= 2
-	 "	bne mode2InnerLoopA"  "\n"
-
-	 "mov %[scanline], r10"    "\n"         // scanline points to start of it.
-	 "movs %[x], 110"          "\n"         // x = 110
-	 "mov %[t], r11"           "\n"         // t = 4096
-	 "mode2InnerLoopB:"
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 MODE2_INNER_LOOP_B
-	 "	bne mode2InnerLoopB"     "\n"
-
-	 "mov %[scanline], r10"    "\n"
-	 "movs %[t], 1"              "\n"
-	 "movs %[c], 88"             "\n"
-	 "add %[y], %[t]"            "\n" // y++... derpy, but it's the outer loop
-	 "cmp %[y], %[c]"            "\n"
-	 "bne mode2OuterLoop"       "\n" // if y != 88, loop
-
-	 : // outputs
-	   [c]"+l" (c),
-	   [t]"+l" (t),
-	   [x]"+l" (x),
-	   [y]"+h" (y),  // +:Read-Write l:lower (0-7) register
-	   [scrbuf]"+l" (scrbuf)
-
-	 : // inputs
-	   [LCD]"l" (0xA0002188),
-	   [scanline]"l" (scanline),
-	   [paletteptr]"l" (paletteptr),
-	   [byte]"l" (byte)
-	 : // clobbers
-	   "cc", "r10", "r11"
-       );
-
-
+void Pokitto::lcdRefreshMode13(const uint8_t* scrbuf, const uint16_t* paletteptr, uint8_t offset){
+#if POK_PERSISTENCE > 0
+    updateMode13Clear(paletteptr, scrbuf, offset, POK_CLEAR_SCREEN);
 #else
-  write_data(0); // does not have pixel 0 bug
-  write_command(0x22); // write data to DRAM
-  CLR_CS_SET_CD_RD_WR;
-  SET_MASK_P2;
-
-uint8_t* d = scrbuf;// point to beginning of line in data
-
-  #ifdef PROJ_SHOW_FPS_COUNTER
-  wait_us(200); // Add wait to compensate skipping of 8 lines. Makes FPS counter to show the correct value.
-  for(y=4;y<88;y++)
-  #else
-  for(y=0;y<88;y++)
-  #endif
-  {
-
-    // Write the horizontal line to the scanline, and write the scanline to LCD.
-    uint8_t s=0;
-    for(x=0;x<110;x+=2)
-    {
-      uint8_t t = *d++;
-      uint32_t color;
-      color = uint32_t(paletteptr[t>>4])<<3;
-      scanline[s]=*LCD=color;TGL_WR_OP(s++);TGL_WR;
-      color = uint32_t(paletteptr[t&0xF])<<3;
-      scanline[s]=*LCD=color;TGL_WR_OP(s++);TGL_WR;
-    }
-
-    // Write a duplicate scanline to the next horizontal line in LCD.
-    s=0;
-    for (s=0;s<110;) {
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-      *LCD = (scanline[s]);TGL_WR_OP(s++);TGL_WR;
-    }
-
-  }
+    updateMode13(paletteptr, scrbuf, offset);
 #endif
-
- CLR_MASK_P2;
 }
 
-void Pokitto::lcdRefreshMode3(uint8_t * scrbuf, uint16_t* paletteptr) {
-uint16_t x,y;
-uint16_t scanline[2][176]; // read two nibbles = pixels at a time
-uint8_t *d;
-
-write_command(0x20);  // Horizontal DRAM Address
-write_data(0);  // 0
-write_command(0x21);  // Vertical DRAM Address
-write_data(0);
-write_command(0x22); // write data to DRAM
-CLR_CS_SET_CD_RD_WR;
-
-for(x=0;x<220;x+=2)
-  {
-    d = scrbuf+(x>>1);// point to beginning of line in data
-    /** find colours in one scanline **/
-    uint8_t s=0;
-    for(y=0;y<176;y++)
-    {
-    uint8_t t = *d >> 4; // higher nibble
-    uint8_t t2 = *d & 0xF; // lower nibble
-    /** higher nibble = left pixel in pixel pair **/
-    scanline[0][s] = paletteptr[t];
-    scanline[1][s++] = paletteptr[t2];
-    /** testing only **/
-    //scanline[0][s] = 0xFFFF*(s&1);
-    //scanline[1][s] = 0xFFFF*(!(s&1));
-    //s++;
-    /** until here **/
-    d+=220/2; // jump to read byte directly below in screenbuffer
-    }
-    s=0;
-    /** draw scanlines **/
-    /** leftmost scanline**/
-
-    #ifdef PROJ_SHOW_FPS_COUNTER
-    if (x<8) continue;
-    setDRAMptr(x, 0);
-    #endif
-
-    for (s=0;s<176;) {
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-    }
-
-    /** rightmost scanline**/
-    //setDRAMptr(xptr++,yoffset);
-    for (s=0;s<176;) {
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-    }
-  }
+void Pokitto::lcdRefreshMode64( const uint8_t* scrbuf, const uint16_t* paletteptr ){
+#if POK_PERSISTENCE > 0
+    updateMode64Clear(paletteptr, scrbuf, POK_CLEAR_SCREEN);
+#else
+    updateMode64(paletteptr, scrbuf);
+#endif
 }
 
-void Pokitto::lcdRefreshGB(uint8_t * scrbuf, uint16_t* paletteptr) {
-uint16_t x,y;
-uint16_t scanline[48];
-uint8_t * d;
+void Pokitto::lcdRefreshMode15(const uint8_t* scrbuf, const uint16_t* paletteptr){
+    uint32_t palette[16];
+    for( uint32_t i=0; i<16; ++i )
+        palette[i] = uint32_t(paletteptr[i]) << 3;
 
-#if POK_STRETCH
-//uint16_t xptr = 8;
+#if POK_PERSISTENCE > 0
+    updateMode15Clear(palette, scrbuf, POK_CLEAR_SCREEN);
 #else
-//xptr = 26;
+    updateMode15(palette, scrbuf);
 #endif
-
-write_command(0x20);  // Horizontal DRAM Address
-write_data(0);  // 0
-write_command(0x21);  // Vertical DRAM Address
-write_data(0);
-write_command(0x22); // write data to DRAM
-CLR_CS_SET_CD_RD_WR;
-
-/** draw border **/
-    for (int s=0;s<5*176;) {
-            setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;s++;
-    }
-
-for(x=0;x<84;x++)
-  {
-
-        d = scrbuf + x;// point to beginning of line in data
-
-        /** find colours in one scanline **/
-        uint8_t s=0;
-        for(y=0;y<6;y++)
-            {
-            uint8_t t = *d;
-            #if POK_COLORDEPTH > 1
-            uint8_t t2 = *(d+504);
-            #endif
-            #if POK_COLORDEPTH > 2
-            uint8_t t3 = *(d+504+504);
-            #endif
-            #if POK_COLORDEPTH > 3
-            uint8_t t4 = *(d+504+504+504);
-            #endif
-            uint8_t paletteindex = 0;
-
-            /** bit 1 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x1);
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x1)) | ((t2 & 0x01)<<1);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = (t & 0x1) | ((t2 & 0x1)<<1) | ((t3 & 0x1)<<2);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = (t & 0x1) | ((t2 & 0x1)<<1) | ((t3 & 0x1)<<2) | ((t4 & 0x1)<<3);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 2 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x2)>>1;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x2)>>1) | ((t2 & 0x02));
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x2)>>1) | ((t2 & 0x2)) | ((t3 & 0x2)<<1);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x2)>>1) | ((t2 & 0x2)) | ((t3 & 0x2)<<1) | ((t4 & 0x2)<<2);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 3 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x4)>>2;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 4)>>2) | ((t2 & 0x04)>>1);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x4)>>2) | ((t2 & 0x4)>>1) | (t3 & 0x4);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x4)>>2) | ((t2 & 0x4)>>1) | (t3 & 0x4) | ((t4 & 0x4)<<1);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 4 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x8)>>3;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x8)>>3) | ((t2 & 0x08)>>2);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x8)>>3) | ((t2 & 0x8)>>2) | ((t3 & 0x8)>>1);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x8)>>3) | ((t2 & 0x8)>>2) | ((t3 & 0x8)>>1) | (t4 & 0x8);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 5 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x10)>>4;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x10)>>4) | ((t2 & 0x10)>>3);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x10)>>4) | ((t2 & 0x10)>>3) | ((t3 & 0x10)>>2);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x10)>>4) | ((t2 & 0x10)>>3) | ((t3 & 0x10)>>2) | ((t4 & 0x10)>>1);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 6 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x20)>>5;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x20)>>5) | ((t2 & 0x20)>>4);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x20)>>5) | ((t2 & 0x20)>>4) | ((t3 & 0x20)>>3);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x20)>>5) | ((t2 & 0x20)>>4) | ((t3 & 0x20)>>3) | ((t4 & 0x20)>>2);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 7 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x40)>>6;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x40)>>6) | ((t2 & 0x40)>>5);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x40)>>6) | ((t2 & 0x40)>>5) | ((t3 & 0x40)>>4) ;
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x40)>>6) | ((t2 & 0x40)>>5) | ((t3 & 0x40)>>4) | ((t4 & 0x40)>>3);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 8 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x80)>>7;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x80)>>7) | ((t2 & 0x80)>>6);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x80)>>7) | ((t2 & 0x80)>>6) | ((t3 & 0x80)>>5);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x80)>>7) | ((t2 & 0x80)>>6) | ((t3 & 0x80)>>5) | ((t4 & 0x80)>>4);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            d+=84; // jump to byte directly below
-            }
-
-
-        /*write_command(0x20);  // Horizontal DRAM Address
-        write_data(0x10);  // 0
-        write_command(0x21);  // Vertical DRAM Address
-        write_data(xptr++);
-        write_command(0x22); // write data to DRAM
-        CLR_CS_SET_CD_RD_WR;*/
-        /** draw border **/
-        setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;        CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-
-        s=0;
-
-        /** draw scanlines **/
-        for (s=0;s<48;) {
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-        }
-        /** draw border **/
-        setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;        CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-
-
-        /*write_command(0x20);  // Horizontal DRAM Address
-        write_data(0x10);  // 0
-        write_command(0x21);  // Vertical DRAM Address
-        write_data(xptr++);
-        write_command(0x22); // write data to DRAM
-        CLR_CS_SET_CD_RD_WR;*/
-        /** draw border **/
-        setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;        CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-
-        for (s=0;s<48;) {
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-        }
-
-        /** draw border **/
-        setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;        CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-
-
-        #if POK_STRETCH
-        //if (x>16 && x<68)
-        if (x&2)// && x&2)
-        {
-            /*write_command(0x20);  // Horizontal DRAM Address
-            write_data(0x10);  // 0
-            write_command(0x21);  // Vertical DRAM Address
-            write_data(xptr++);
-            write_command(0x22); // write data to DRAM
-            CLR_CS_SET_CD_RD_WR;*/
-            /** draw border **/
-        setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;        CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-
-
-            for (s=0;s<48;) {
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-            }
-
-            /** draw border **/
-        setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;        CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;CLR_WR;SET_WR;
-
-        }
-        #endif
-    }
-    /** draw border **/
-    for (int s=0;s<5*176;) {
-            setup_data_16(COLOR_BLACK);CLR_WR;SET_WR;s++;
-    }
 }
-
-
-void Pokitto::lcdRefreshAB(uint8_t * scrbuf, uint16_t* paletteptr) {
-uint16_t x,y;
-uint16_t scanline[64];
-uint8_t *d;
-//lcdClear();
-#if POK_STRETCH
-uint16_t xptr = 14;
-uint8_t yoffset = 24;
-#else
-uint16_t xptr = 0;
-uint8_t yoffset = 0;
-#endif
-
-for(x=0;x<128;x++)
-  {
-    write_command(0x20);  // Horizontal DRAM Address
-    write_data(yoffset);  // 0
-    write_command(0x21);  // Vertical DRAM Address
-    write_data(xptr++);
-    write_command(0x22); // write data to DRAM
-    CLR_CS_SET_CD_RD_WR;
-    //setDRAMptr(xptr++,yoffset);
-
-        d = scrbuf + x;// point to beginning of line in data
-
-        /** find colours in one scanline **/
-        uint8_t s=0;
-        for(y=0;y<8;y++)
-            {
-            uint8_t t = *d;
-            #if POK_COLORDEPTH > 1
-            uint8_t t2 = *(d+AB_JUMP);
-            #endif // POK_COLORDEPTH
-            #if POK_COLORDEPTH > 2
-            uint8_t t3 = *(d+AB_JUMP+AB_JUMP);
-            #endif // POK_COLORDEPTH
-            #if POK_COLORDEPTH > 3
-            uint8_t t4 = *(d+AB_JUMP+AB_JUMP+AB_JUMP);
-            #endif // POK_COLORDEPTH
-            uint8_t paletteindex = 0;
-
-            /** bit 1 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x1);
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x1)) | ((t2 & 0x01)<<1);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = (t & 0x1) | ((t2 & 0x1)<<1) | ((t3 & 0x1)<<2);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = (t & 0x1) | ((t2 & 0x1)<<1) | ((t3 & 0x1)<<2) | ((t4 & 0x1)<<3);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 2 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x2)>>1;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x2)>>1) | ((t2 & 0x02));
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x2)>>1) | ((t2 & 0x2)) | ((t3 & 0x2)<<1);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x2)>>1) | ((t2 & 0x2)) | ((t3 & 0x2)<<1) | ((t4 & 0x2)<<2);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 3 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x4)>>2;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 4)>>2) | ((t2 & 0x04)>>1);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x4)>>2) | ((t2 & 0x4)>>1) | (t3 & 0x4);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x4)>>2) | ((t2 & 0x4)>>1) | (t3 & 0x4) | ((t4 & 0x4)<<1);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 4 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x8)>>3;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x8)>>3) | ((t2 & 0x08)>>2);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x8)>>3) | ((t2 & 0x8)>>2) | ((t3 & 0x8)>>1);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x8)>>3) | ((t2 & 0x8)>>2) | ((t3 & 0x8)>>1) | (t4 & 0x8);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 5 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x10)>>4;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x10)>>4) | ((t2 & 0x10)>>3);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x10)>>4) | ((t2 & 0x10)>>3) | ((t3 & 0x10)>>2);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x10)>>4) | ((t2 & 0x10)>>3) | ((t3 & 0x10)>>2) | ((t4 & 0x10)>>1);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 6 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x20)>>5;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x20)>>5) | ((t2 & 0x20)>>4);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x20)>>5) | ((t2 & 0x20)>>4) | ((t3 & 0x20)>>3);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x20)>>5) | ((t2 & 0x20)>>4) | ((t3 & 0x20)>>3) | ((t4 & 0x20)>>2);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 7 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x40)>>6;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x40)>>6) | ((t2 & 0x40)>>5);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x40)>>6) | ((t2 & 0x40)>>5) | ((t3 & 0x40)>>4) ;
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x40)>>6) | ((t2 & 0x40)>>5) | ((t3 & 0x40)>>4) | ((t4 & 0x40)>>3);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            /** bit 8 **/
-            #if POK_COLORDEPTH == 1
-            paletteindex = (t & 0x80)>>7;
-            #elif POK_COLORDEPTH == 2
-            paletteindex = ((t & 0x80)>>7) | ((t2 & 0x80)>>6);
-            #elif POK_COLORDEPTH == 3
-            paletteindex = ((t & 0x80)>>7) | ((t2 & 0x80)>>6) | ((t3 & 0x80)>>5);
-            #elif POK_COLORDEPTH == 4
-            paletteindex = ((t & 0x80)>>7) | ((t2 & 0x80)>>6) | ((t3 & 0x80)>>5) | ((t4 & 0x80)>>4);
-            #endif
-            scanline[s++] = paletteptr[paletteindex];
-
-            d+=128; // jump to byte directly below
-            }
-
-        s=0;
-
-        /** draw scanlines **/
-        for (s=0;s<64;) {
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-        }
-
-        #if POK_STRETCH
-        if (x&1) {
-        write_command(0x20);  // Horizontal DRAM Address
-        write_data(yoffset);  // 0
-        write_command(0x21);  // Vertical DRAM Address
-        write_data(xptr++);
-        write_command(0x22); // write data to DRAM
-        CLR_CS_SET_CD_RD_WR;
-        //setDRAMptr(xptr++,yoffset);
-
-        for (s=0;s<64;) {
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;CLR_WR;SET_WR;
-        }
-        }
-        #endif
-    }
-}
-
-void Pokitto::lcdRefreshModeGBC(uint8_t * scrbuf, uint16_t* paletteptr) {
-uint16_t x,y,xptr;
-uint16_t scanline[4][144]; // read 4 half-nibbles = 4 pixels at a time
-uint8_t *d, yoffset=0;
-
-xptr = 0;
-setDRAMptr(xptr,yoffset);
-
-
-for(x=0;x<160;x+=4)
-  {
-    d = scrbuf+(x>>2);// point to beginning of line in data
-    /** find colours in one scanline **/
-    uint8_t s=0;
-    for(y=0;y<144;y++)
-    {
-    uint8_t tdata = *d;
-    uint8_t t4 = tdata & 0x03; tdata >>= 2;// lowest half-nibble
-    uint8_t t3 = tdata & 0x03; tdata >>= 2;// second lowest half-nibble
-    uint8_t t2 = tdata & 0x03; tdata >>= 2;// second highest half-nibble
-    uint8_t t = tdata & 0x03;// highest half-nibble
-
-    /** put nibble values in the scanlines **/
-
-    scanline[0][s] = paletteptr[t];
-    scanline[1][s] = paletteptr[t2];
-    scanline[2][s] = paletteptr[t3];
-    scanline[3][s++] = paletteptr[t4];
-
-     d+=160/4; // jump to read byte directly below in screenbuffer
-    }
-
-    s=0;
-    /** draw scanlines **/
-    for (s=0;s<144;) {
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-    }
-    setDRAMptr(++xptr,yoffset);
-    for (s=0;s<144;) {
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-    }
-    setDRAMptr(++xptr,yoffset);
-    for (s=0;s<144;) {
-        setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[2][s++]);CLR_WR;SET_WR;
-    }
-    setDRAMptr(++xptr,yoffset);
-    for (s=0;s<144;) {
-        setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[3][s++]);CLR_WR;SET_WR;
-    }
-    setDRAMptr(++xptr,yoffset);
-  }
-}
-
-
-void Pokitto::lcdRefreshT1(uint8_t* tilebuf, uint8_t* tilecolorbuf, uint8_t* tileset, uint16_t* paletteptr) {
-#ifdef POK_TILEMODE
-uint16_t x,y,data,xptr;
-uint16_t scanline[176];
-uint8_t yoffset=0, tilebyte, tileindex, tilex=0, tiley=0,xcount;
-
-
-if (!tileset) return;
-
-#if LCDWIDTH < POK_LCD_W
-xptr = (POK_LCD_W-LCDWIDTH)/2;
-#else
-xptr = 0;
-#endif
-#if LCDHEIGHT < POK_LCD_H
-yoffset = (POK_LCD_H-LCDHEIGHT)/2;
-#else
-yoffset = 0;
-#endif
-
-for(x=0, xcount=0 ;x<LCDWIDTH;x++,xcount++)  // loop through vertical columns
-  {
-    setDRAMptr(xptr++,yoffset); //point to VRAM
-
-        /** find colours in one scanline **/
-        uint8_t s=0, tiley=0;
-        //tileindex = tilebuf[tilex*POK_TILES_Y];
-        if (xcount==POK_TILE_W) {
-            tilex++;
-            xcount=0;
-        }
-
-        for(y=0;y<LCDHEIGHT;)
-        {
-            uint8_t tileval = tilebuf[tilex+tiley*POK_TILES_X]; //get tile number
-            uint16_t index = tileval*POK_TILE_W+xcount;
-            uint8_t tilebyte = tileset[index]; //get bitmap data
-            for (uint8_t ycount=0, bitcount=0; ycount<POK_TILE_H; ycount++, y++, bitcount++) {
-                if (bitcount==8) {
-                    bitcount=0;
-                    index += 176; //jump to byte below in the tileset bitmap
-                    tilebyte = tileset[index]; //get bitmap data
-                }
-                //tilebyte = tile[(tileindex>>4)+*POK_TILE_W]; //tilemaps are 16x16
-                //uint8_t paletteindex = ((tilebyte>>(bitcount&0x7)) & 0x1);
-                if (!tileval) scanline[s++] = COLOR_MAGENTA*((tilebyte>>bitcount)&0x1);//paletteptr[paletteindex];
-                else scanline[s++] = paletteptr[((tilebyte>>bitcount)&0x1)*tileval];//paletteptr[paletteindex];
-            }
-            tiley++; //move to next tile
-        }
-        s=0;
-
-        /** draw scanlines **/
-        for (s=0;s<LCDHEIGHT;) {
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-        }
-    }
-    #endif
-}
-
-#define MODE13_INNER_LOOP_A						\
-	       "	add %[t], %[t], r10"	   "\n" 		\
-	       "	uxtb %[c], %[t] " "\n"				\
-	       "	lsls %[c], 1"             "\n"			\
-	       "	ldrh %[t], [%[paletteptr], %[c]]"      "\n"	\
-	       "	lsls %[t], %[t], 3"       "\n"			\
-	       "	str %[t], [%[LCD], 0]"    "\n"			\
-	       "	movs %[c], 252"   "\n"				\
-	       "	str %[offset], [%[LCD], %[c]]" "\n"		\
-	       "	stm %[scanline]!, {%[t]}"      "\n"		\
-	       "	str %[offset], [%[LCD], 124]"  "\n"		\
-	       "	str %[offset], [%[LCD], %[c]]" "\n"		\
-	       "	adds %[scrbuf], %[scrbuf], 1" "\n"		\
-	       "	ldrb %[t], [%[scrbuf],0]"   "\n"		\
-	       "	str %[offset], [%[LCD], 124]"  "\n"
-
-// This can be made 1 cycle faster (x -= 10 instead of x--),
-// but there will be noise
-#define MODE13_INNER_LOOP_B					\
-	       "	str %[c], [%[LCD], 0]"    "\n"		\
-	       "	str %[offset], [%[LCD], %[t]]" "\n"	\
-	       "	ldr %[c], [%[scanline]]"   "\n"		\
-	       "	str %[offset], [%[LCD], 124]"  "\n"	\
-	       "	str %[offset], [%[LCD], %[t]]" "\n"	\
-	       "	adds %[scanline], 4"             "\n"	\
-	       "	subs %[x], 1"			"\n"	\
-	       "	str %[offset], [%[LCD], 124]"  "\n"
-
-
- void Pokitto::lcdRefreshMode13(uint8_t * scrbuf, uint16_t* paletteptr, uint8_t offset){
-   uint32_t scanline[110]; // read two nibbles = pixels at a time
-
-   write_command_16(0x03); write_data_16(0x1038);
-   write_command(0x20); write_data(0);
-   write_command(0x21); write_data(0);
-   write_command(0x22);
-   CLR_CS_SET_CD_RD_WR;
-   SET_MASK_P2;
-
-   uint32_t x, y=0, c, t;
-
-#ifndef __ARMCC_VERSION
-   #ifdef PROJ_SHOW_FPS_COUNTER
-   setDRAMptr(0, 8);
-   y=4;
-   #endif
-
-   asm volatile(
-	 ".syntax unified"         "\n"
-
-	 "mov r10, %[offset]"	   "\n"
-	 "movs %[offset], 1"            "\n"
-	 "lsls %[offset], %[offset], 12"     "\n"
-
-	 "mode13OuterLoop:"        "\n"
-
-	 "movs %[x], 110"          "\n"
-	 "ldrb %[t], [%[scrbuf],0]"   "\n"
-	 "mode13InnerLoopA:"
-	 MODE13_INNER_LOOP_A
-	 MODE13_INNER_LOOP_A
-	 "	subs %[x], 2"          "\n"
-	 "	bne mode13InnerLoopA"  "\n"
-
-	 "subs %[scanline], 220"    "\n"
-	 "subs %[scanline], 220"    "\n"
-
-	 "movs %[x], 110"          "\n"
-	 "movs %[t], 252"           "\n"
-	 "ldm %[scanline]!, {%[c]}"   "\n"
-	 "mode13InnerLoopB:"
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 MODE13_INNER_LOOP_B
-	 "	bne mode13InnerLoopB"     "\n"
-
-	 "subs %[scanline], 220"    "\n"
-	 "subs %[scanline], 224"    "\n"
-	 "movs %[t], 1"              "\n"
-	 "movs %[c], 88"             "\n"
-	 "add %[y], %[t]"            "\n"
-	 "cmp %[y], %[c]"            "\n"
-	 "bne mode13OuterLoop"       "\n" // if y != 88, loop
-
-	 : // outputs
-	   [c]"+l" (c),
-	   [t]"+l" (t),
-	   [x]"+l" (x),
-	   [y]"+h" (y),  // +:Read-Write l:lower (0-7) register
-	   [scrbuf]"+l" (scrbuf),
-	   [offset]"+l" (offset)
-
-	 : // inputs
-	   [LCD]"l" (0xA0002188),
-	   [scanline]"l" (scanline),
-	   [paletteptr]"l" (paletteptr)
-
-	 : // clobbers
-	   "cc", "r10"
-       );
-
-#else
-   uint8_t* d = scrbuf;// point to beginning of line in data
-   for(y=0;y<88;y++){
-
-     uint32_t* s = scanline;
-
-     for(x=0;x<110;x+=10){
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-       *LCD = *s = paletteptr[(*d + offset)&255]<<3; TGL_WR_OP(s++);TGL_WR_OP(d++);
-     }
-
-     s = scanline;
-     uint32_t c = *s;
-     for(x=0;x<110;x+=10){
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-       *LCD = c; TGL_WR_OP(s++);TGL_WR_OP(c=*s);
-     }
-
-   }
-#endif
- }
-
-
-
- void Pokitto::lcdRefreshMode64( uint8_t * scrbuf, uint16_t* paletteptr ){
-   uint8_t *end = &scrbuf[ POK_SCREENBUFFERSIZE+4 ];
-   write_command_16(0x03); write_data_16(0x1038);
-   write_command(0x20); write_data(0);
-#ifdef PROJ_SHOW_FPS_COUNTER
-  write_data(8);
-  scrbuf += 110*8;
-#else
-  write_data(0);
-#endif
-   write_command(0x21); write_data(0);
-   write_command(0x22);
-   CLR_CS_SET_CD_RD_WR;
-   SET_MASK_P2;
-
-   uint32_t TGL = 1<<12, CLR = 252, c, t;
-#ifndef __ARMCC_VERSION
-   asm volatile(
-	 ".syntax unified"         "\n"
-	 "ldm %[scrbuf]!, {%[c]}" "\n"
-	 "lsls %[t], %[c], 24" 			"\n"
-	 "mode64loop%=:"    "\n"
-	 "lsrs %[c], %[c], 8" 			"\n"
-	 "lsrs %[t], %[t], 23" 			"\n"
-	 "ldrh %[t], [%[paletteptr], %[t]]" 	"\n"
-	 "lsls %[t], 3" 			"\n"
-	 "str %[t], [%[LCD], 0]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "lsls %[t], %[c], 24" 			"\n"
-	 "lsrs %[c], %[c], 8" 			"\n"
-	 "lsrs %[t], %[t], 23" 			"\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "ldrh %[t], [%[paletteptr], %[t]]" 	"\n"
-	 "lsls %[t], 3" 			"\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-
-	 "str %[t], [%[LCD], 0]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "lsls %[t], %[c], 24" 			"\n"
-	 "lsrs %[t], %[t], 23" 			"\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "ldrh %[t], [%[paletteptr], %[t]]" 	"\n"
-	 "lsls %[t], 3" 			"\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-	 "str %[t], [%[LCD], 0]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "lsrs %[c], %[c], 8" 			"\n"
-	 "lsls %[t], %[c], 1" 			"\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "ldrh %[t], [%[paletteptr], %[t]]" 	"\n"
-	 "lsls %[t], 3" 			"\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-
-	 "str %[t], [%[LCD], 0]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "ldm %[scrbuf]!, {%[c]}" "\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-	 "str %[TGL], [%[LCD], %[CLR]]" 	"\n"
-	 "lsls %[t], %[c], 24" 			"\n"
-	 "cmp %[scrbuf], %[end]" "\n"
-	 "str %[TGL], [%[LCD], 124]" 		"\n"
-
-	 "bne mode64loop%=" "\n"
-
-	 : // outputs
-	   [c]"+l" (c),
-	   [t]"+l" (t),
-	   [scrbuf]"+l" (scrbuf)
-
-	 : // inputs
-	   [CLR]"l" (CLR),
-	   [TGL]"l" (TGL),
-	   [LCD]"l" (0xA0002188),
-	   [paletteptr]"l" (paletteptr),
-	   [end]"h" (end)
-
-	 : // clobbers
-	   "cc"
-       );
-
-#else
-
-   c = uint32_t(paletteptr[(*scrbuf)&255])<<3;
-   while( scrbuf < end-4 ){
-       *LCD = c; TGL_WR_OP(scrbuf++);TGL_WR_OP( c = uint32_t(paletteptr[(*scrbuf)&255])<<3 );
-       *LCD = c; TGL_WR_OP(scrbuf++);TGL_WR_OP( c = uint32_t(paletteptr[(*scrbuf)&255])<<3 );
-       *LCD = c; TGL_WR_OP(scrbuf++);TGL_WR_OP( c = uint32_t(paletteptr[(*scrbuf)&255])<<3 );
-       *LCD = c; TGL_WR_OP(scrbuf++);TGL_WR_OP( c = uint32_t(paletteptr[(*scrbuf)&255])<<3 );
-   }
-
-#endif
- }
-
-
-
-void Pokitto::lcdRefreshMode14(uint8_t * scrbuf, uint16_t* paletteptr) {
-uint16_t x,y,data,xptr;
-uint16_t scanline[176]; uint16_t* scptr;
-uint8_t *d;
-
-write_command(0x20); write_data(0);
-write_command(0x21); write_data(0);
-write_command(0x22);
-CLR_CS_SET_CD_RD_WR;
-
-for(x=0;x<220;x++)
-  {
-        d = scrbuf+x;
-        scptr = &scanline[0];
-
-        /** find colours in one scanline **/
-        /*for(y=0;y<22;y++)
-            {
-
-            uint16_t t = *d;
-            uint16_t t2 = *(d+POK_BITFRAME);
-            uint16_t t3 = *(d+POK_BITFRAME+POK_BITFRAME);
-
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-            *scptr++ = (t & 0x1)*R_MASK | (t2 & 0x1)*G_MASK | (t3 & 0x1)*B_MASK; t >>= 1;t2 >>= 1;t3 >>= 1;
-
-
-            d+=220; // jump to word directly below
-            }
-        */
-        /** alternative way: go through one color at a time **/
-            scptr = &scanline[0]; // set to beginning of scanline
-            for(y=0;y<22;y++, d +=220)
-            {
-            uint16_t t = *d & 0xFF;
-
-            *scptr++ = R_MASK * (t&0x1); t >>= 1;
-            *scptr++ = R_MASK * (t&0x1); t >>= 1;
-            *scptr++ = R_MASK * (t&0x1); t >>= 1;
-            *scptr++ = R_MASK * (t&0x1); t >>= 1;
-            *scptr++ = R_MASK * (t&0x1); t >>= 1;
-            *scptr++ = R_MASK * (t&0x1); t >>= 1;
-            *scptr++ = R_MASK * (t&0x1); t >>= 1;
-            *scptr++ = R_MASK * (t&0x1);
-            }
-            scptr = &scanline[0]; // set to beginning of scanline
-            d = scrbuf+x+POK_BITFRAME;
-            for(y=0;y<22;y++, d +=220)
-            {
-            uint16_t t = *d & 0xFF;
-
-            *scptr++ |= G_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= G_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= G_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= G_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= G_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= G_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= G_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= G_MASK * (t&0x1);
-            }
-            scptr = &scanline[0]; // set to beginning of scanline
-            d = scrbuf+x+POK_BITFRAME*2;
-            for(y=0;y<22;y++, d +=220)
-            {
-            uint16_t t = *d & 0xFF;
-
-            *scptr++ |= B_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= B_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= B_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= B_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= B_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= B_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= B_MASK * (t&0x1); t >>= 1;
-            *scptr++ |= B_MASK * (t&0x1);
-            }
-
-
-        #ifdef PROJ_SHOW_FPS_COUNTER
-        if (x<8) continue;
-        setDRAMptr(x, 0);
-        #endif
-
-        /** draw scanlines **/
-        for (int s=0;s<176;) {
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-            setup_data_16(scanline[s++]);CLR_WR;SET_WR;
-
-        }
-
-    }
-}
-
-//#define ADEKTOSMODE15
-
-#ifdef ADEKTOSMODE15
-void Pokitto::lcdRefreshMode15(uint16_t* pal, uint8_t* scrbuf){
-    write_command(0x03); write_data(0x1038); //realy only need to call this once
-    write_command(0x20); write_data(0);
-    write_command(0x21); write_data(0);
-
-    write_command(0x22);
-
-    #ifdef PROJ_SHOW_FPS_COUNTER
-    for (int x=0,xt=0; x<0x4BA0;x++,xt++) {
-    if (xt==110) xt=0;
-    if (xt<8) {
-        write_data(0);
-        write_data(0);
-    } else {
-        write_data(pal[(((scrbuf[x]) & 0xf0) >> 4)]);
-        write_data(pal[( (scrbuf[x]) & 0x0f)]);
-    }
-
-    }
-    #else
-    for (int x=0; x<0x4BA0;x++) {
-        write_data(pal[(((scrbuf[x]) & 0xf0) >> 4)]);
-        write_data(pal[( (scrbuf[x]) & 0x0f)]);
-    }
-    #endif //PROJ_SHOW_FPS_COUNTER
-}
-
-#else
-
-void Pokitto::lcdRefreshMode15(uint16_t* paletteptr, uint8_t* scrbuf){
-//    #define __ARMCC_VERSION
-#ifndef __ARMCC_VERSION
-
-#define MODE15_LOOP				\
-    "ands %[tmp], %[color]" "\n"		\
-	"lsrs %[tmp], 2" "\n"			\
-	"ldr %[tmp], [%[palette], %[tmp]]" "\n" \
-	"str %[tmp], [%[LCD]]" "\n"		\
-	"str %[WRBit], [%[LCD], %[CLR]]" "\n"	\
-	"movs %[tmp], 0x0F" "\n"		\
-	"ands %[tmp], %[color]" "\n"		\
-	"str %[WRBit], [%[LCD], 124]" "\n"	\
-	"lsls %[tmp], 2" "\n"			\
-	"ldr %[tmp], [%[palette], %[tmp]]" "\n" \
-	"str %[tmp], [%[LCD]]" "\n"		\
-	"str %[WRBit], [%[LCD], %[CLR]]" "\n"	\
-	"movs %[tmp], 0xF0" "\n"		\
-	"lsrs %[color], 8" "\n"			\
-	"str %[WRBit], [%[LCD], 124]" "\n"
-
-#define MODE15_ENDLOOP					\
-    "ands %[tmp], %[color]" "\n"			\
-	"lsrs %[tmp], 2" "\n"				\
-	"ldr %[tmp], [%[palette], %[tmp]]" "\n"		\
-	"str %[tmp], [%[LCD]]" "\n"			\
-	"str %[WRBit], [%[LCD], %[CLR]]" "\n"		\
-	"movs %[tmp], 0x0F" "\n"			\
-	"ands %[tmp], %[color]" "\n"			\
-	"str %[WRBit], [%[LCD], 124]" "\n"		\
-	"lsls %[tmp], 2" "\n"				\
-	"ldr %[tmp], [%[palette], %[tmp]]" "\n"		\
-	"str %[tmp], [%[LCD]]" "\n"			\
-	"str %[WRBit], [%[LCD], %[CLR]]" "\n"		\
-	"ldm %[scrbuf]!, {%[color]}" "\n"		\
-	"movs %[tmp], 0xF0" "\n"			\
-	"str %[WRBit], [%[LCD], 124]" "\n"
-
-  uint8_t *end=&scrbuf[POK_SCREENBUFFERSIZE]+4;
-  volatile uint32_t palette[16];
-  for( uint32_t i=0; i<16; ++i )
-      palette[i] = uint32_t(paletteptr[i]) << 3;
-
-  write_command(0x03); write_data(0x1038);
-  write_command(0x21);  // Vertical DRAM Address
-  write_data(0);
-  write_command(0x20);  // Horizontal DRAM Address
-#ifdef PROJ_SHOW_FPS_COUNTER
-  write_data(8);
-  scrbuf += 110*8;
-#else
-  write_data(0);
-#endif
-  write_command(0x22); // write data to DRAM
-  CLR_CS_SET_CD_RD_WR;
-
-
-  SET_MASK_P2;
-
-  uint32_t WRBit = 1<<12, color, tmp;
-  asm volatile(
-      ".syntax unified" "\n"
-      "ldm %[scrbuf]!, {%[color]}" "\n"
-      "movs %[tmp], 0xF0" "\n"
-      "mode15Loop%=:" "\n"
-      MODE15_LOOP
-      MODE15_LOOP
-      MODE15_LOOP
-      MODE15_ENDLOOP
-      "cmp %[end], %[scrbuf]" "\n"
-      "bne mode15Loop%=" "\n"
-      :
-      [tmp]"+l" (tmp),
-      [color]"+l" (color),
-      [end]"+h" (end),
-      [scrbuf]"+l" (scrbuf),
-      [WRBit]"+l" (WRBit)
-
-      :
-      [CLR]"l" (252),
-      [LCD]"l" (0xA0002188),
-      [palette]"l" (palette)
-
-      :
-      "cc"
-      );
-
-#else
-
-uint16_t x,y,xptr;
-uint16_t scanline[2][176]; // read two nibbles = pixels at a time
-uint8_t *d, yoffset=0;
-
-xptr = 0;
-//setDRAMptr(xptr,yoffset);
-
-write_command(0x20); write_data(0);
-write_command(0x21); write_data(0);
-write_command(0x22);
-CLR_CS_SET_CD_RD_WR;
-
-for(x=0;x<220;x+=2)
-  {
-    d = scrbuf+(x>>1);// point to beginning of line in data
-    // find colours in one scanline
-    uint8_t s=0;
-    for(y=0;y<176;y++)
-    {
-    uint8_t t = *d >> 4; // higher nibble
-    uint8_t t2 = *d & 0xF; // lower nibble
-    // higher nibble = left pixel in pixel pair
-    scanline[0][s] = paletteptr[t];
-    scanline[1][s++] = paletteptr[t2];
-
-    d+=220/2; // jump to read byte directly below in screenbuffer
-    }
-    s=0;
-    // draw scanlines
-
-    #ifdef PROJ_SHOW_FPS_COUNTER
-    if (x<8) continue;
-    setDRAMptr(x, 0);
-    #endif
-
-    for (s=0;s<176;) {
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[0][s++]);CLR_WR;SET_WR;
-    }
-
-    for (s=0;s<176;) {
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-        setup_data_16(scanline[1][s++]);CLR_WR;SET_WR;
-    }
-  }
-
-#endif
-
-}
-#endif //ADEKTOSMODE15
 
 void Pokitto::lcdRefreshMixMode(const uint8_t * screenBuffer, const uint16_t * palettePointer, const uint8_t * scanType)
 {
-	write_command(0x03);
-	write_data(0x1038);
+    uint32_t scanline[220];
 
-	// Horizontal DRAM Address
-	write_command(0x20);
-	write_data(0);
+    // point to beginning of line in data
+    const uint8_t * d = screenBuffer;
+    for(uint32_t y = 0; y < 176; ++y)
+    {
+        // find colours in one scanline
+        uint8_t scanTypeIndex = y >> 1;
+        uint8_t lineIndex = 0;
+        switch(scanType[scanTypeIndex])
+        {
+        case 0:
+        {
+            // point to beginning of line in data
+            d = &screenBuffer[110 * scanTypeIndex];
+            for(uint8_t x = 0; x < (220 / 2); ++x)
+            {
+                uint32_t color = static_cast<uint32_t>(palettePointer[*d]) << 3;
+                ++d;
+                scanline[lineIndex] = color;
+                ++lineIndex;
+                scanline[lineIndex] = color;
+                ++lineIndex;
+            }
+            break;
+        }
+        case 1:
+        {
+            for(uint8_t x = 0; x < (220 / 4); ++x)
+            {
+                uint8_t t = *d;
+                ++d;
 
-	// Vertical DRAM Address
-	write_command(0x21);
-	write_data(0);
+                uint32_t color1 = static_cast<uint32_t>(palettePointer[256 + (t >> 4)]) << 3;
+                scanline[lineIndex] = color1;
+                ++lineIndex;
+                scanline[lineIndex] = color1;
+                ++lineIndex;
 
-	// write data to DRAM
-	write_command(0x22);
-	CLR_CS_SET_CD_RD_WR;
-	SET_MASK_P2;
+                uint32_t color2 = static_cast<uint32_t>(palettePointer[256 + (t & 0xF)]) << 3;
+                scanline[lineIndex] = color2;
+                ++lineIndex;
+                scanline[lineIndex] = color2;
+                ++lineIndex;
+            }
+            break;
+        }
+        case 2:
+        {
+            for(uint8_t x = 0; x < (220 / 4); ++x)
+            {
+                uint8_t t = *d;
+                ++d;
 
-	uint32_t scanline[220];
+                scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 6) & 0x03)]) << 3;
+                ++lineIndex;
 
-	// point to beginning of line in data
-	const uint8_t * d = screenBuffer;
-	for(uint32_t y = 0; y < 176; ++y)
-	{
-		// find colours in one scanline
-		uint8_t scanTypeIndex = y >> 1;
-		uint8_t lineIndex = 0;
-		switch(scanType[scanTypeIndex])
-		{
-			case 0:
-			{
-				// point to beginning of line in data
-				d = &screenBuffer[110 * scanTypeIndex];
-				for(uint8_t x = 0; x < (220 / 2); ++x)
-				{
-					uint32_t color = static_cast<uint32_t>(palettePointer[*d]) << 3;
-					++d;
-					scanline[lineIndex] = color;
-					++lineIndex;
-					scanline[lineIndex] = color;
-					++lineIndex;
-				}
-				break;
-			}
-			case 1:
-			{
-				for(uint8_t x = 0; x < (220 / 4); ++x)
-				{
-					uint8_t t = *d;
-					++d;
+                scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 4) & 0x03)]) << 3;
+                ++lineIndex;
 
-					uint32_t color1 = static_cast<uint32_t>(palettePointer[256 + (t >> 4)]) << 3;
-					scanline[lineIndex] = color1;
-					++lineIndex;
-					scanline[lineIndex] = color1;
-					++lineIndex;
+                scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 2) & 0x03)]) << 3;
+                ++lineIndex;
 
-					uint32_t color2 = static_cast<uint32_t>(palettePointer[256 + (t & 0xF)]) << 3;
-					scanline[lineIndex] = color2;
-					++lineIndex;
-					scanline[lineIndex] = color2;
-					++lineIndex;
-				}
-				break;
-			}
-			case 2:
-			{
-				for(uint8_t x = 0; x < (220 / 4); ++x)
-				{
-					uint8_t t = *d;
-					++d;
-
-					scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 6) & 0x03)]) << 3;
-					++lineIndex;
-
-					scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 4) & 0x03)]) << 3;
-					++lineIndex;
-
-					scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 2) & 0x03)]) << 3;
-					++lineIndex;
-
-					scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 0) & 0x03)]) << 3;
-					++lineIndex;
-				}
-				break;
-			}
-		}
+                scanline[lineIndex] = static_cast<uint32_t>(palettePointer[272 + ((t >> 0) & 0x03)]) << 3;
+                ++lineIndex;
+            }
+            break;
+        }
+        }
 
         uint32_t color = scanline[0];
-        #define WRITE_SCANLINE *LCD = color; TGL_WR_OP(color = scanline[++i]);
+#define WRITE_SCANLINE *LCD = color; TGL_WR_OP(color = scanline[++i]);
 
-		volatile uint32_t * LCD = reinterpret_cast< volatile uint32_t * >(0xA0002188);
-		for (uint8_t i = 0; i < 220;)
-		{
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
-			WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
+        for (uint8_t i = 0; i < 220;)
+        {
+            WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE	WRITE_SCANLINE
+                WRITE_SCANLINE  WRITE_SCANLINE	WRITE_SCANLINE
 		}
 
-		#undef WRITE_SCANLINE
-	}
+#undef WRITE_SCANLINE
+    }
 
-	CLR_MASK_P2;
+    CLR_MASK_P2;
 }
-
 
 void Pokitto::blitWord(uint16_t c) {
     setup_data_16(c);CLR_WR;SET_WR;

--- a/Pokitto/POKITTO_HW/HWLCD.h
+++ b/Pokitto/POKITTO_HW/HWLCD.h
@@ -46,19 +46,25 @@
 
 extern volatile uint32_t *LCD;
 
+extern "C" {
+    void flushLine(const uint16_t *palette, const uint8_t *line);
+    void pixelCopy(uint8_t* dest, const uint8_t *src, uint32_t count, uint32_t recolor=0);
+    void pixelCopyMirror(uint8_t* dest, const uint8_t *src, uint32_t count, uint32_t recolor=0);
+    void pixelCopySolid(uint8_t* dest, const uint8_t *src, uint32_t count, uint32_t recolor=0);
+    void updateMode1(const volatile uint32_t *palette, const uint8_t *buffer );
+    void updateMode1Clear(const volatile uint32_t *palette, const uint8_t *buffer, int clearColor );
+    void updateMode2(const uint16_t *palette, const uint8_t *buffer );
+    void updateMode2Clear(const uint16_t *palette, const uint8_t *buffer, int clearColor );
+    void updateMode13(const uint16_t *palette, const uint8_t *buffer, int offset );
+    void updateMode13Clear(const uint16_t *palette, const uint8_t *buffer, int offset, int clearColor );
+    void updateMode15(const uint32_t *palette, const uint8_t *buffer );
+    void updateMode15Clear(const uint32_t *palette, const uint8_t *buffer, int clear );
+    void updateMode64(const uint16_t *palette, const uint8_t *buffer );
+    void updateMode64Clear(const uint16_t *palette, const uint8_t *buffer, int clearColor );
+}
+
 namespace Pokitto {
-
-struct SpriteInfo {
-    const uint8_t* bitmapData;
-    int16_t x;
-    int16_t y;
-    int16_t oldx;
-    int16_t oldy;
-    uint8_t w;
-    uint8_t h;
-    uint16_t palette[4];
-};
-
+extern void lcdPrepareRefresh();
 extern void setDRAMpoint(uint8_t, uint8_t);
 extern void pumpDRAMdata(uint16_t*, uint16_t);
 extern void initBacklight();
@@ -72,23 +78,14 @@ extern void lcdInit();
 extern void lcdSleep();
 extern void lcdWakeUp();
 extern void lcdRefresh(uint8_t *, uint16_t*);
-extern void lcdRefreshAB(uint8_t *, uint16_t*);
-extern void lcdRefreshMode14(uint8_t *, uint16_t*);
-extern void lcdRefreshGB(uint8_t *, uint16_t*);
-extern void lcdRefreshMode1(uint8_t* scrbuf, uint8_t updRectX, uint8_t updRectY, uint8_t updRectW, uint8_t updRectH, uint16_t* paletteptr);
-extern void lcdRefreshMode1Spr(uint8_t * scrbuf, uint8_t screenx, uint8_t screeny, uint8_t screenw, uint8_t screenh, uint16_t* paletteptr, Pokitto::SpriteInfo* sprites, bool drawSpritesOnly);
-extern void lcdRefreshMode2(uint8_t *, uint16_t*);
-extern void lcdRefreshMode3(uint8_t *, uint16_t*);
-extern void lcdRefreshModeGBC(uint8_t *, uint16_t*);
-extern void lcdRefreshMode13(uint8_t *, uint16_t*, uint8_t);
+extern void lcdRefreshMode1(const uint8_t* scrbuf, const uint16_t* paletteptr);
+extern void lcdRefreshMode2(const uint8_t *, const uint16_t*);
+extern void lcdRefreshMode13(const uint8_t *, const uint16_t*, uint8_t);
 extern void lcdRefreshMixMode(const uint8_t *, const uint16_t*, const uint8_t*);
-extern void lcdRefreshMode64(uint8_t *, uint16_t*);
+extern void lcdRefreshMode64(const uint8_t*, const uint16_t*);
+extern void lcdRefreshMode15(const uint8_t*, const uint16_t*);
+extern void lcdRefreshTASMode(uint8_t*, const uint16_t*);
 
-extern void lcdRefreshMode15(uint16_t*, uint8_t*);
-
-
-/** Update LCD from 1-bit tile mode */
-extern void lcdRefreshT1(uint8_t*, uint8_t*, uint8_t*, uint16_t*);
 extern void lcdClear();
 extern void lcdFill(uint16_t);
 /** Blit one word of data*/

--- a/Pokitto/POKITTO_HW/asm/SystemInit.asm
+++ b/Pokitto/POKITTO_HW/asm/SystemInit.asm
@@ -1,0 +1,579 @@
+# SystemInit.S by FManga
+# This code is in the PUBLIC DOMAIN
+
+.code 16
+.syntax unified
+
+# LPC
+.equ LPC_SCT_CONFIG, 0x5000C000
+.equ LPC_SCT_CTRL, 0x5000C004
+
+.equ LPC_SYSPLLCTRL,    0x40048008  
+.equ LPC_SYSOSCCTRL,    0x40048020
+.equ LPC_SYSPLLCLKSTAT, 0x4004800C
+.equ LPC_SYSPLLCLKSEL,  0x40048040
+.equ LPC_SYSPLLCLKUEN,  0x40048044
+.equ LPC_SYSAHBCLKCTRL, 0x40048080
+
+.equ LPC_MAINCLKSEL,   0x40048070
+.equ LPC_MAINCLKUEN,   0x40048074
+.equ LPC_SYSAHBCLKDIV, 0x40048078
+.equ LPC_USBPLLCTRL,   0x40048010
+.equ LPC_USBPLLSTAT,   0x40048014
+.equ LPC_USBPLLCLKSEL, 0x40048048
+.equ LPC_USBPLLCLKUEN, 0x4004804C
+.equ LPC_USBCLKSEL,    0x400480C0
+.equ LPC_USBCLKDIV,    0x400480C8
+.equ LPC_PDRUNCFG,   0x40048238
+.equ LPC_SYSPLLSTAT, 0x4004800C
+.equ LPC_SSP0CLKDIV, 0x40048094
+
+.equ LPC_RTCCTRL, 0x40024000
+     
+.equ LPC_PRESETCTRL, 0x40048004
+
+.equ LPC_SPI0_CR0, 0x40040000
+.equ LPC_SPI0_CR1, 0x40040004
+.equ LPC_SPI0_CPSR, 0x40040010
+
+.equ LPC_GPIO_PORT_DIR0, 0xA0002000
+.equ LPC_GPIO_PORT_DIR1, 0xA0002004
+.equ LPC_GPIO_PORT_DIR2, 0xA0002008
+
+.equ LPC_GPIO_PORT_MASK0, 0xA0002080
+.equ LPC_GPIO_PORT_MASK1, 0xA0002084
+.equ LPC_GPIO_PORT_MASK2, 0xA0002088
+
+.equ LPC_GPIO_PORT_PIN0, 0xA0002100
+.equ LPC_GPIO_PORT_PIN1, 0xA0002104
+.equ LPC_GPIO_PORT_PIN2, 0xA0002108
+
+.equ LPC_GPIO_PORT_MPIN0, 0xA0002180
+.equ LPC_GPIO_PORT_MPIN1, 0xA0002184
+.equ LPC_GPIO_PORT_MPIN2, 0xA0002188
+	
+.equ LPC_GPIO_PORT_CLR0, 0xA0002280
+.equ LPC_GPIO_PORT_CLR1, 0xA0002284
+.equ LPC_GPIO_PORT_CLR2, 0xA0002288
+
+.equ LPC_GPIO_PORT_SET0, 0xA0002200
+.equ LPC_GPIO_PORT_SET1, 0xA0002204
+.equ LPC_GPIO_PORT_SET2, 0xA0002208
+
+.equ LPC_GPIO_PORT_NOT0, 0xA0002300
+.equ LPC_GPIO_PORT_NOT1, 0xA0002304
+.equ LPC_GPIO_PORT_NOT2, 0xA0002308
+
+.equ LCD_CD_PORT, 0
+.equ LCD_CD_PIN, 2
+.equ LCD_WR_PORT, 1
+.equ LCD_WR_PIN, 12
+.equ LCD_RD_PORT, 1
+.equ LCD_RD_PIN, 24
+.equ LCD_RES_PORT, 1
+.equ LCD_RES_PIN, 0
+
+.equ LCD_CD_SET, LPC_GPIO_PORT_SET0
+.equ LCD_CD_CLR, LPC_GPIO_PORT_CLR0
+.equ LCD_WR_SET, LPC_GPIO_PORT_SET1
+.equ LCD_WR_CLR, LPC_GPIO_PORT_CLR1
+.equ LCD_RD_SET, LPC_GPIO_PORT_SET1
+.equ LCD_RD_CLR, LPC_GPIO_PORT_CLR1
+.equ LCD_RES_SET, LPC_GPIO_PORT_SET1
+.equ LCD_RES_CLR, LPC_GPIO_PORT_CLR1
+.equ LCD_MPIN, LPC_GPIO_PORT_MPIN2
+
+.equ PIO0_6, 0x40044018
+.equ PIO0_8, 0x40044020     
+.equ PIO0_9, 0x40044024     
+.equ PIO1_31, 0x400440DC
+.equ PIO2_0,  0x400440F0
+.equ PIO2_1,  0x400440F4
+.equ PIO2_2,  0x400440FC
+     
+.equ ARM_NVIC_ISER, 0xe000e100
+     
+.macro lcd_clr_cd scratch_bit:req, scratch_ptr:req
+	movs \scratch_bit, (1<<LCD_CD_PIN)
+	ldr \scratch_ptr, =LPC_GPIO_PORT_CLR0
+	str \scratch_bit, [\scratch_ptr]
+.endm
+
+.macro lcd_write data:req, scratch:req
+	ldr \scratch, =LPC_GPIO_PORT_MPIN0
+	lsls \data, \data, #3
+	str \data, [\scratch, #8]
+.endm	
+
+# PVCOPY
+
+.macro SET REG:req, VAL:req
+.word \REG
+.word \VAL
+.endm
+
+.macro CALL REG:req, VAL:req
+.word (\REG)+1
+.word \VAL
+.endm
+
+.macro OR REG:req, VAL:req
+.word \REG+2
+.word \VAL
+.endm
+
+.macro AND REG:req, VAL:req
+.word \REG+3
+.word \VAL
+.endm
+
+.macro END
+.word 0
+.endm
+
+
+.global SystemInit
+.global PVCOPY
+
+.func PVCOPY
+PVCOPY:
+	push {r4, lr}
+	ldr r4, =jmptbl
+	movs r2, r0
+next:	
+	movs r3, #3
+	ldm r2!, {r0, r1}
+	cmp r0, #0
+	beq exit
+	ands r3, r0
+	lsls r3, #2
+	ldr r3, [r4, r3]
+	bx r3
+	
+exit:
+	pop {r4, pc}
+	
+PVCOPYSET:
+	str r1, [r0]
+	b next
+	
+PVCOPYFUN:
+	movs r3, r0
+	movs r0, r1
+	lsrs r1, r3, #24
+	lsls r3, #8
+	lsrs r3, #8
+	adds r1, #1
+1:	
+	push {r1, r2, r3, r4}
+	blx r3
+	pop {r1, r2, r3, r4}
+	subs r1, #1
+	beq next
+	ldm r2!, {r0}
+	b 1b
+
+PVCOPYOR:
+	lsrs r0, #2
+	lsls r0, #2
+	ldr r3, [r0]
+	orrs r3, r1
+	str r3, [r0]
+	b next
+	
+PVCOPYAND:
+	lsrs r0, #2
+	lsls r0, #2
+	ldr r3, [r0]
+	ands r3, r1
+	str r3, [r0]
+	b next
+
+	.pool
+jmptbl:	
+	.word PVCOPYSET+1
+	.word PVCOPYFUN+1
+	.word PVCOPYOR+1
+	.word PVCOPYAND+1
+.endfunc
+	
+
+	
+// like memset, but for words and word-aligned memory
+.func wordset	
+wordset:
+	cmp r1, 0
+	beq 2f
+1:	
+	stm r0!, {r2}
+	subs r1, 4
+	bgt 1b
+2:	
+	bx lr
+.endfunc
+
+.func poll
+.align 4
+poll:
+	ldr r1, [r0]
+        lsls r1, 31
+	beq poll
+	bx lr
+.endfunc
+
+.func toggle
+.align 4
+toggle:
+	movs r1, 1
+	str r1, [r0]
+	movs r2, 0
+	str r2, [r0]
+	str r1, [r0]
+	bx lr
+.endfunc
+	
+.func SystemInit
+SystemInit:
+	push {lr}
+	ldr r0, =PIO2_2
+	movs r1, 68
+	movs r2, 0x80
+	bl wordset
+	ldr r0, =PV_INIT_GPIO
+	bl PVCOPY
+	pop {pc}
+.endfunc
+	
+.func wait
+wait:
+	movs r1, #10
+1:	
+	subs r1, #1
+	bne 1b
+	subs r0, #1
+	bne wait
+	bx lr
+.endfunc	
+
+.macro WAIT_MS MS:req
+	CALL wait, \MS
+.endm
+
+.func lcdCmd
+.align 4
+lcdCmd: 				// r0 = cmd<<16 + arg
+	lsrs r1, r0, #16 		// r1 = cmd
+	uxth r0, r0 	 		// remove cmd from r0
+
+	lcd_clr_cd r3, r4		// CLR_CD. r3 = pin, r4 = CLR0
+
+	// MPIN[2] = CMD<<3
+	ldr r2, =LPC_GPIO_PORT_MPIN0
+	lsls r1, r1, #3
+	str r1, [r2, #8]
+	
+	movs r1, r2			// r1 = MPIN
+	
+	ldr r3, =(1<<LCD_WR_PIN)	// CLR_WR
+	str r3, [r4, #4]		// [r4, 4] is CLR1. LCD_WR_PORT
+
+	lsls r0, r0, #3			// data = data<<3
+	nop
+					// SET_WR
+	ldr r2, =LPC_GPIO_PORT_SET0
+	str r3, [r2, #4]		// [r2, 4] is SET1. LCD_WR_PORT
+	
+	movs r3, (1<<LCD_CD_PIN)
+	str r3, [r2, #0]		// SET_CD. [r2, 0] is SET0.
+	
+	str r0, [r1, #8]		// MPIN[2] = data (r0)
+	
+	ldr r3, =(1<<LCD_WR_PIN)	// CLR_WR
+	str r3, [r4, #4]		// [r4, 4] is CLR1. LCD_WR_PORT
+
+	nop
+	nop
+					// SET_WR
+	ldr r2, =LPC_GPIO_PORT_SET0
+	str r3, [r2, #4]		// [r2, 4] is SET1. LCD_WR_PORT
+
+	bx lr
+	.pool
+.endFunc
+
+.macro LCD_CMD CMD:req, ARG:req, RPT
+	.word lcdCmd+1 + ((\RPT+0)<<24)
+	.word (\CMD<<16) | (\ARG)
+.endm
+
+.macro LCD_CMD_ARG CMD:req, ARG:req
+	.word (\CMD<<16) | (\ARG)
+.endm
+	
+.align 4
+PV_INIT_GPIO:
+	// system_LPC11U6x.c: 487
+	// enable GPIO | IOCON | SRAM1+SRAM2 | USART0
+	OR LPC_SYSAHBCLKCTRL, (1<<16) | (1<<6) | (1<<30) | (1<<19) | (3<<26) | (1<<12)
+    AND LPC_RTCCTRL, ~1
+    SET LPC_RTCCTRL, (1<<7)
+
+    // init buttons
+    SET 0x40044084,0x88
+    SET 0x40044070,0x88
+    SET 0x40044088,0x88
+    SET 0x40044094,0x88
+    SET 0x4004406c,0x88
+    SET 0x400440c4,0x88
+    SET 0x4004407c,0x88
+
+	// 488 // same is repeated further down.
+	// SET LPC_SYSPLLCTRL, 0x23
+	
+	// 494, 495
+	SET PIO2_0, 1
+	SET PIO2_1, 1
+
+	// 497 - Redundant? Default is already 0.
+	SET LPC_SYSOSCCTRL, 0
+
+	// 498
+	AND LPC_PDRUNCFG, ~(1<<5)
+
+	WAIT_MS 250
+
+	// 507
+	SET LPC_SYSPLLCLKSEL, 1
+
+	// 508
+	CALL toggle, LPC_SYSPLLCLKUEN
+
+	// 511 // this line in system_LPC11U6x.c makes no sense.
+	// CALL poll, LPC_SYSPLLCLKSTAT
+
+	// 522
+	OR LPC_PDRUNCFG, 1<<7
+
+    //    .ifdef OSCT
+	// 523
+	SET LPC_SYSPLLCTRL, 0x25
+    //    .else
+	// 523
+	//SET LPC_SYSPLLCTRL, 0x23
+    //    .endif
+
+	// 522
+	AND LPC_PDRUNCFG, ~(1<<7)
+
+	// 525
+	CALL poll, LPC_SYSPLLSTAT
+
+	// 528
+	SET LPC_MAINCLKSEL, 3
+
+	// 529
+	CALL toggle, LPC_MAINCLKUEN
+		
+	// 532
+	CALL poll, LPC_MAINCLKUEN
+
+	// 534
+	SET LPC_SYSAHBCLKDIV, 1
+
+	// 556, 559
+	AND LPC_PDRUNCFG, ~(1<<10) & ~(1<<8)
+
+	// 560
+	SET LPC_USBPLLCLKSEL, 1
+
+	// 561
+	CALL toggle, LPC_USBPLLCLKUEN
+
+	// 564
+	CALL poll, LPC_USBPLLCLKUEN
+
+	// 566
+	SET LPC_USBPLLCTRL, 0x23
+
+	// 567
+	CALL poll, LPC_USBPLLSTAT
+
+	// 569
+	SET LPC_USBCLKSEL, 0
+
+	// 573
+	SET LPC_USBCLKDIV, 1
+
+/*
+	// spi_api.c:77
+	SET LPC_SSP0CLKDIV, 1
+	// spi_api.c:79
+	OR LPC_PRESETCTRL, 1
+
+	// spi_api.c:89
+	SET PIO0_9, 0x81
+	SET PIO0_8, 0x81
+	SET PIO0_6, 0x82
+
+// SPI.cpp
+	// disable ssp, set lbm, ms, sod, divider to 0
+	AND LPC_SPI0_CR1, ~(1<<1) & ~0xD & ~0xFF00
+
+	SET LPC_SPI0_CR0, 0x7
+
+	// set prescaler to 0. spi_frequency:151
+	SET LPC_SPI0_CPSR, 0
+	
+	OR LPC_SPI0_CR1, (1<<1) // enable ssp
+*/
+// end SPI.cpp
+	
+	SET ARM_NVIC_ISER, 0x7F
+	SET PIO1_31, 0x80
+	
+	SET LPC_GPIO_PORT_MASK0, 0
+	SET LPC_GPIO_PORT_MASK1, 0
+	SET LPC_GPIO_PORT_MASK2, ~(0x7FFF8)
+
+	// #define LCD_CD_PORT           0
+	// #define LCD_CD_PIN            2
+	// LPC_GPIO_PORT->DIR[LCD_CD_PORT] |= (1  << LCD_CD_PIN );
+	// GPIO_DIR[0]:
+	SET LPC_GPIO_PORT_DIR0, 0x00000004
+
+	// #define LCD_WR_PORT           1
+	// #define LCD_WR_PIN            12
+	// LPC_GPIO_PORT->DIR[LCD_WR_PORT] |= (1  << LCD_WR_PIN );
+	// #define LCD_RD_PORT           1
+	// #define LCD_RD_PIN            24
+	// LPC_GPIO_PORT->DIR[LCD_RD_PORT] |= (1  << LCD_RD_PIN );
+	// #define LCD_RES_PORT          1
+	// #define LCD_RES_PIN           0	
+	// LPC_GPIO_PORT->DIR[LCD_RES_PORT] |= (1  << LCD_RES_PIN );
+	// GPIO_DIR[1]:
+	SET LPC_GPIO_PORT_DIR1, 0x01001001
+	
+	// LPC_GPIO_PORT->DIR[2] |= (1  << 2 );
+	// LPC_GPIO_PORT->DIR[2] |= (0xFFFF  << 3);  // P2_3...P2_18 as output
+	// GPIO_DIR[2]:
+	SET LPC_GPIO_PORT_DIR2, 0x0007FFFC
+
+	SET LPC_GPIO_PORT_PIN0, 0
+	
+	// #define LCD_RES_PORT          1
+	// #define LCD_RES_PIN           0
+	// #define SET_RESET LPC_GPIO_PORT->SET[LCD_RES_PORT] = 1 << LCD_RES_PIN; // RST
+	SET LPC_GPIO_PORT_PIN1, (1<<LCD_RES_PIN)
+	
+	// LPC_GPIO_PORT->SET[2] = 1 << 2; // backlight
+	SET LPC_GPIO_PORT_PIN2, 1 << 2
+	// LCD initialization
+
+	// Reset LCD
+	WAIT_MS 10
+ 	SET LPC_GPIO_PORT_CLR1, (1<<LCD_RES_PIN)
+	WAIT_MS 10
+	// (LCD_RD high = write)
+ 	SET LPC_GPIO_PORT_SET1, (1<<LCD_RES_PIN) | (1<<LCD_RD_PIN)
+	WAIT_MS 10
+	// driver output control, this also affects direction
+	LCD_CMD 0x01, 0x11C, 9
+
+	// originally: 0x11C 100011100 SS,NL4,NL3,NL2
+        // NL4...0 is the number of scan lines to drive the screen !!!
+        // so 11100 is 1c = 220 lines, correct
+        // test 1: 0x1C 11100 SS=0,NL4,NL3,NL2 -> no effect
+        // test 2: 0x31C 1100011100 GS=1,SS=1,NL4,NL3,NL2 -> no effect
+        // test 3: 0x51C 10100011100 SM=1,GS=0,SS=1,NL4,NL3,NL2 -> no effect
+        // test 4: 0x71C SM=1,GS=1,SS=1,NL4,NL3,NL2
+        // test 5: 0x
+        // seems to have no effect... is this perhaps only for RGB mode ?
+
+	// LCD driving control
+	LCD_CMD_ARG 0x02,0x0100
+	// INV = 1
+	
+	// Entry mode... lets try if this affects the direction
+	LCD_CMD_ARG 0x03,0x1038
+	// originally 0x1030 1000000110000 BGR,ID1,ID0
+        // test 1: 0x1038 1000000111000 BGR,ID1,ID0,AM=1 ->drawing DRAM horizontally
+        // test 4: am=1, id0=0, id1=0, 1000000001000,0x1008 -> same as above, but flipped on long
+        // test 2: am=0, id0=0, 1000000100000, 0x1020 -> flipped on long axis
+        // test 3: am=0, id1=0, 1000000010000, 0x1010 -> picture flowed over back to screen
+
+	// Display control 2
+	LCD_CMD_ARG 0x08,0x0808 // 100000001000 FP2,BP2
+	
+	// RGB display interface
+	LCD_CMD_ARG 0x0C,0x0000 // all off
+	
+	// Frame marker position
+	LCD_CMD_ARG 0x0F,0x0001 // OSC_EN
+	
+	// Horizontal DRAM Address
+	LCD_CMD_ARG 0x20,0x0000
+
+	// Vertical DRAM Address
+	LCD_CMD_ARG 0x21,0x0000
+	
+// *************Power On sequence ****************
+	LCD_CMD_ARG 0x10,0x0000
+	LCD_CMD_ARG 0x11,0x1000
+	
+	WAIT_MS 10
+//------------------------ Set GRAM area --------------------------------
+	// Gate scan position
+	LCD_CMD 0x30,0x0000, 9 // if GS=0, 00h=G1, else 00h=G220
+	
+	// Vertical scroll control
+	LCD_CMD_ARG 0x31,0x00DB // scroll start line 11011011 = 219
+	
+	// Vertical scroll control
+	LCD_CMD_ARG 0x32,0x0000 // scroll end line 0
+	
+	// Vertical scroll control
+	LCD_CMD_ARG 0x33,0x0000 // 0=vertical scroll disabled
+	
+	// Partial screen driving control
+	LCD_CMD_ARG 0x34,0x00DB // db = full screen (end)
+	
+	// partial screen
+	LCD_CMD_ARG 0x35,0x0000 // 0 = start
+	
+	// Horizontal and vertical RAM position
+	LCD_CMD_ARG 0x36,0x00AF //end address 175
+	
+	LCD_CMD_ARG 0x37,0x0000
+	LCD_CMD_ARG 0x38,0x00DB //end address 219
+	
+
+	LCD_CMD_ARG 0x39,0x0000 // start address 0
+	WAIT_MS 10
+	
+	// start gamma register control
+	LCD_CMD 0xff,0x0003, 13
+// ----------- Adjust the Gamma  Curve ----------//
+	LCD_CMD_ARG 0x50,0x0203	
+	LCD_CMD_ARG 0x51,0x0A09	
+	LCD_CMD_ARG 0x52,0x0005	
+	LCD_CMD_ARG 0x53,0x1021	
+	LCD_CMD_ARG 0x54,0x0602	
+	LCD_CMD_ARG 0x55,0x0003	
+	LCD_CMD_ARG 0x56,0x0703	
+	LCD_CMD_ARG 0x57,0x0507	
+	LCD_CMD_ARG 0x58,0x1021	
+	LCD_CMD_ARG 0x59,0x0703	
+	LCD_CMD_ARG 0xB0,0x2501	
+	LCD_CMD_ARG 0xFF,0x0000	
+	LCD_CMD_ARG 0x07,0x1017
+	
+	SET LCD_CD_CLR, (1<<LCD_CD_PIN)
+	SET LCD_MPIN,   (0x22)<<3
+	SET LCD_WR_CLR, (1<<LCD_WR_PIN)
+	SET LCD_WR_SET, (1<<LCD_WR_PIN)
+	SET LCD_CD_SET, (1<<LCD_CD_PIN)
+
+        // Set Reset button to GPIO
+        // SET 0x40044000,0x89
+	
+	END

--- a/Pokitto/POKITTO_HW/asm/flushLine.s
+++ b/Pokitto/POKITTO_HW/asm/flushLine.s
@@ -1,0 +1,63 @@
+# flushLine.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global flushLine
+
+# void flushLine(uint16_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"))
+.func flushLine
+PALETTE .req r0
+SCRBUF .req r1
+
+# locals
+LCD .req r2
+WRBIT .req r3
+COLOR .req r4
+TMP .req r5
+CLR .req r6
+END .req r7
+
+.macro UNROLL
+    uxtb TMP, COLOR
+    lsls TMP, 1
+    ldrh TMP, [PALETTE, TMP]
+    lsls TMP, 3
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    lsrs COLOR, 8
+    uxtb TMP, COLOR
+    str WRBIT, [LCD, 124]
+.endm
+
+flushLine:
+    push {r4-r7, lr}
+    ldr LCD,   =0xA0002188
+    ldr WRBIT, =1<<12
+    ldr CLR,   =252
+    ldr END, =220
+    adds END, SCRBUF
+    
+    ldm SCRBUF!, {COLOR}
+    loop:
+
+        UNROLL
+        UNROLL
+        UNROLL
+    
+        uxtb TMP, COLOR
+        lsls TMP, 1
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str TMP, [LCD]
+        str WRBIT, [LCD, CLR]
+        cmp SCRBUF, END   
+        ldm SCRBUF!, {COLOR}
+        str WRBIT, [LCD, 124]
+
+    bne loop
+
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode1.s
+++ b/Pokitto/POKITTO_HW/asm/mode1.s
@@ -1,0 +1,104 @@
+# mode1.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode1
+
+# void updateMode1(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"))
+.func updateMode1
+PALETTE .req r0
+SCRBUF .req r1
+
+# locals
+LCD .req r2
+WRBIT .req r3
+COLOR .req r4
+TMP .req r5
+PAIR .req r6
+CLR .req r7
+END .req r8
+
+.macro MODE1_LOOP
+    adds TMP, PALETTE
+    ldm TMP, {TMP, PAIR}
+    str TMP, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+    str WRBIT, [LCD, 124]
+    str PAIR, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+    movs TMP, 0x0F
+    ands TMP, COLOR
+    str WRBIT, [LCD, 124]
+    
+    lsls TMP, 3
+    adds TMP, PALETTE
+    ldm TMP, {TMP, PAIR}
+    str TMP, [LCD, 0]
+    movs TMP, 252
+    str WRBIT, [LCD, TMP]
+    str WRBIT, [LCD, 124]
+    str PAIR, [LCD, 0]
+    str WRBIT, [LCD, TMP]
+    lsrs COLOR, 8
+    movs TMP, 0xF0
+    ands TMP, TMP, COLOR
+    lsrs TMP, TMP, 1
+    str WRBIT, [LCD, 124]
+.endm
+
+updateMode1:
+    push {r4-r7, lr}
+    mov r4, r8
+    push {r4}
+    
+    ldr r4, =0x25D4
+    adds r4, SCRBUF
+    mov END, r4
+    ldr LCD,   =0xA0002188
+    ldr WRBIT, =1<<12
+    ldr CLR,   =252
+    
+    ldm SCRBUF!, {COLOR}     // load 4 bytes (16 pixels)
+    movs TMP, 0xF0
+    ands TMP, COLOR
+    lsrs TMP, 1
+    mode1Loop:
+        MODE1_LOOP
+        MODE1_LOOP
+        MODE1_LOOP
+        adds TMP, PALETTE
+        ldm TMP, {TMP, PAIR}
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        movs TMP, 0x0F
+        str WRBIT, [LCD, 124]
+        str PAIR, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        ands TMP, TMP, COLOR
+        str WRBIT, [LCD, 124]
+    
+        lsls TMP, 3
+        adds TMP, PALETTE
+        ldm TMP, {TMP, PAIR}
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        movs TMP, 0xF0
+        str WRBIT, [LCD, 124]
+        str PAIR, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+    
+        ldm SCRBUF!, {COLOR} // load next 4 bytes
+        ands TMP, TMP, COLOR
+        lsrs TMP, TMP, 1
+        str WRBIT, [LCD, 124]
+
+        cmp END, SCRBUF
+    bne mode1Loop // if scrbuf < end, loop
+
+    pop {r4}
+    mov r8, r4
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode13.s
+++ b/Pokitto/POKITTO_HW/asm/mode13.s
@@ -1,0 +1,110 @@
+# mode13.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode13
+
+# void updateMode13(uint16_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"))
+.func updateMode13
+PALETTE .req r0
+SCRBUF .req r1
+OFFSET .req r9
+
+# locals
+WRBIT .req r2
+LCD .req r3
+C .req r4
+T .req r5
+X .req r6
+Y .req r8
+SCANLINE .req r7
+
+.macro MODE13_INNER_LOOP_A
+    add T, OFFSET
+    uxtb C, T 
+    lsls C, 1
+    ldrh T, [PALETTE, C]
+    lsls T, 3
+    str T, [LCD]
+    movs C, 252
+    str WRBIT, [LCD, C]
+    stm SCANLINE!, {T}
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, C]
+    adds SCRBUF, 1
+    ldrb T, [SCRBUF]
+    str WRBIT, [LCD, 124]
+.endm
+
+.macro MODE13_INNER_LOOP_B
+    // This can be made 1 cycle faster (x -= 10 instead of x--), but there will be noise
+    str C, [LCD]
+    str WRBIT, [LCD, T]
+    ldr C, [SCANLINE]
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, T]
+    adds SCANLINE, 4
+    subs X, 1
+    str WRBIT, [LCD, 124]
+.endm
+
+updateMode13:
+    push {r4-r7, lr}
+    mov r4, r8
+    mov r5, r9
+    mov r6, r10
+    push {r4-r6}
+    sub sp, 110*4
+
+    movs LCD, 0
+    mov Y, LCD
+    ldr LCD,   =0xA0002188
+    mov OFFSET, r2
+    ldr WRBIT, =1<<12
+    mov SCANLINE, sp
+    
+    mode13OuterLoop:
+    
+        movs X, 110
+        ldrb T, [SCRBUF]
+        mode13InnerLoopA:
+        	 MODE13_INNER_LOOP_A
+        	 MODE13_INNER_LOOP_A
+        subs X, 2
+        bne mode13InnerLoopA
+        
+        mov SCANLINE, sp
+        
+        movs X, 110
+        movs T, 252
+        ldm SCANLINE!, {C}
+        mode13InnerLoopB:
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        bne mode13InnerLoopB
+        
+        mov SCANLINE, sp
+        movs T, 1
+        movs C, 88
+        add Y, T
+        cmp Y, C
+    blt mode13OuterLoop
+
+    add sp, 110*4
+    pop {r4-r6}
+    mov r8, r4
+    mov r9, r5
+    mov r10, r6
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode13c.s
+++ b/Pokitto/POKITTO_HW/asm/mode13c.s
@@ -1,0 +1,116 @@
+# mode13c.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode13Clear
+
+# void updateMode13Clear(uint16_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"), int clear)
+.func updateMode13Clear
+PALETTE .req r0
+SCRBUF .req r1
+OFFSET .req r9
+CLEAR  .req r10
+
+# locals
+WRBIT .req r2
+LCD .req r3
+C .req r4
+T .req r5
+X .req r6
+Y .req r8
+SCANLINE .req r7
+
+.macro MODE13_INNER_LOOP_A
+    add T, OFFSET
+    uxtb C,T 
+    lsls C, 1
+    ldrh T, [PALETTE, C]
+    lsls T, 3
+    str T, [LCD]
+    movs C, 252
+    str WRBIT, [LCD, C]
+    stm SCANLINE!, {T}
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, C]
+    adds SCRBUF, 1
+    ldrb T, [SCRBUF]
+    str WRBIT, [LCD, 124]
+.endm
+
+.macro MODE13_INNER_LOOP_B
+    // This can be made 1 cycle faster (x -= 10 instead of x--), but there will be noise
+    str C, [LCD]
+    str WRBIT, [LCD, T]
+    ldr C, [SCANLINE]
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, T]
+    adds SCANLINE, 4
+    subs X, 1
+    str WRBIT, [LCD, 124]
+.endm
+
+updateMode13Clear:
+    push {r4-r7, lr}
+    mov r4, r8
+    mov r5, r9
+    mov r6, r10
+    push {r4-r6}
+    sub sp, 110*4
+
+    mov CLEAR, r3
+    movs LCD, 0
+    mov Y, LCD
+    ldr LCD,   =0xA0002188
+    mov OFFSET, r2
+    ldr WRBIT, =1<<12
+    mov SCANLINE, sp
+    
+    mode13OuterLoop:
+    
+        movs X, 110
+        ldrb T, [SCRBUF]
+        mode13InnerLoopA:
+            mov C, CLEAR
+            strb C, [SCRBUF]
+            MODE13_INNER_LOOP_A
+            mov C, CLEAR
+            strb C, [SCRBUF]
+            MODE13_INNER_LOOP_A
+        subs X, 2
+        bne mode13InnerLoopA
+        
+        mov SCANLINE, sp
+        
+        movs X, 110
+        movs T, 252
+        ldm SCANLINE!, {C}
+        mode13InnerLoopB:
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        	 MODE13_INNER_LOOP_B
+        bne mode13InnerLoopB
+        
+        mov SCANLINE, sp
+        movs T, 1
+        movs C, 88
+        add Y, T
+        cmp Y, C
+    blt mode13OuterLoop
+
+    add sp, 110*4
+    pop {r4-r6}
+    mov r8, r4
+    mov r9, r5
+    mov r10, r6
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode15.s
+++ b/Pokitto/POKITTO_HW/asm/mode15.s
@@ -1,0 +1,76 @@
+# mode15.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode15
+
+# void updateMode15(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"))
+.func updateMode15
+PALETTE .req r0
+SCRBUF .req r1
+
+# locals
+LCD .req r2
+WRBIT .req r3
+COLOR .req r4
+TMP .req r5
+CLR .req r6
+END .req r7
+
+.macro MODE15_LOOP
+    ands TMP, COLOR
+    lsrs TMP, 2
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    lsls TMP, COLOR, 28
+    str WRBIT, [LCD, 124]
+    lsrs TMP, 26
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    movs TMP, 0xF0
+    lsrs COLOR, 8 
+    str WRBIT, [LCD, 124]
+.endm
+
+.macro MODE15_ENDLOOP
+    ands TMP, COLOR
+    lsrs TMP, 2
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    lsls TMP, COLOR, 28
+    str WRBIT, [LCD, 124]
+    lsrs TMP, 26
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    ldm SCRBUF!, {COLOR}
+    movs TMP, 0xF0
+	str WRBIT, [LCD, 124]
+.endm
+
+updateMode15:
+    push {r4-r7, lr}
+    ldr LCD,   =0xA0002188
+    ldr WRBIT, =1<<12
+    ldr CLR,   =252
+    ldr END, =0x4BA0
+    adds END, SCRBUF
+    
+    ldm SCRBUF!, {COLOR}
+    mode15Loop:
+    movs TMP, 0xF0
+    MODE15_LOOP
+    MODE15_LOOP
+    MODE15_LOOP
+    MODE15_ENDLOOP
+    cmp SCRBUF, END
+    ble mode15Loop
+
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode15c.s
+++ b/Pokitto/POKITTO_HW/asm/mode15c.s
@@ -1,0 +1,92 @@
+# mode15.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode15Clear
+
+# void updateMode15(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"))
+.func updateMode15Clear
+PALETTE .req r0
+SCRBUF .req r1
+CLEAR .req r2
+
+# locals
+LCD .req r3
+WRBIT .req r4
+COLOR .req r5
+TMP .req r6
+CLR .req r7
+END .req r8
+
+.macro MODE15_LOOP
+    ands TMP, COLOR
+    lsrs TMP, 2
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    lsls TMP, COLOR, 28
+    str WRBIT, [LCD, 124]
+    lsrs TMP, 26
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    movs TMP, 0xF0
+    lsrs COLOR, 8
+    str WRBIT, [LCD, 124]
+.endm
+
+.macro MODE15_ENDLOOP
+    ands TMP, COLOR
+    lsrs TMP, 2
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    lsls TMP, COLOR, 28
+    str WRBIT, [LCD, 124]
+    lsrs TMP, 26
+    ldr TMP, [PALETTE, TMP]
+    str TMP, [LCD]
+    str WRBIT, [LCD, CLR]
+    ldm SCRBUF, {COLOR}
+    movs TMP, 0xF0
+	str WRBIT, [LCD, 124]
+.endm
+
+updateMode15Clear:
+    push {r4-r7, lr}
+    mov r4, r8
+    push {r4}
+    
+    ldr LCD,   =0xA0002188
+    ldr WRBIT, =1<<12
+    ldr CLR,   =252
+    ldr TMP, =0x4BA0
+    add TMP, SCRBUF
+    mov END, TMP
+    
+    lsls TMP, CLEAR, 16
+    orrs CLEAR, TMP
+    lsls TMP, CLEAR, 8
+    orrs CLEAR, TMP
+    lsls TMP, CLEAR, 4
+    orrs CLEAR, TMP
+    
+    ldm SCRBUF, {COLOR}
+    mode15Loop:
+    mov TMP, CLEAR
+    stm SCRBUF!, {TMP}
+    movs TMP, 0xF0
+    MODE15_LOOP
+    MODE15_LOOP
+    MODE15_LOOP
+    MODE15_ENDLOOP
+    cmp SCRBUF, END
+    blt mode15Loop
+
+    pop {r4}
+    mov r8, r4
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode1c.s
+++ b/Pokitto/POKITTO_HW/asm/mode1c.s
@@ -1,0 +1,115 @@
+# mode1c.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode1Clear
+
+# void updateMode1Clear(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"), int clearColor asm("r2"))
+.func updateMode1Clear
+PALETTE .req r0
+SCRBUF .req r1
+CLEAR  .req r9
+
+# locals
+LCD .req r2
+WRBIT .req r3
+COLOR .req r4
+TMP .req r5
+PAIR .req r6
+CLR .req r7
+END .req r8
+
+.macro MODE1_LOOP
+    adds TMP, PALETTE
+    ldm TMP, {TMP, PAIR}
+    str TMP, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+    str WRBIT, [LCD, 124]
+    str PAIR, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+    movs TMP, 0x0F
+    ands TMP, COLOR
+    str WRBIT, [LCD, 124]
+    
+    lsls TMP, 3
+    adds TMP, PALETTE
+    ldm TMP, {TMP, PAIR}
+    str TMP, [LCD, 0]
+    movs TMP, 252
+    str WRBIT, [LCD, TMP]
+    str WRBIT, [LCD, 124]
+    str PAIR, [LCD, 0]
+    str WRBIT, [LCD, TMP]
+    lsrs COLOR, 8
+    movs TMP, 0xF0
+    ands TMP, TMP, COLOR
+    lsrs TMP, TMP, 1
+    str WRBIT, [LCD, 124]
+.endm
+
+updateMode1Clear:
+    push {r4-r7, lr}
+    mov r4, r8
+    mov r5, r9
+    push {r4, r5}
+    
+    lsls tmp, r2, 16
+    orrs r2, tmp
+    lsls tmp, r2, 8
+    orrs r2, tmp
+    lsls tmp, r2, 4
+    orrs r2, tmp
+    lsls tmp, r2, 2
+    orrs r2, tmp
+    mov CLEAR, r2
+    
+    ldr r4, =0x25D4
+    adds r4, SCRBUF
+    mov END, r4
+    ldr LCD,   =0xA0002188
+    ldr WRBIT, =1<<12
+    ldr CLR,   =252
+    
+    mov TMP, CLEAR
+    ldm SCRBUF, {COLOR}     // load 4 bytes (16 pixels)
+    mode1Loop:
+        stm SCRBUF!, {TMP}      // clear 16 pixels
+        movs TMP, 0xF0
+        ands TMP, TMP, COLOR
+        lsrs TMP, TMP, 1
+        MODE1_LOOP
+        MODE1_LOOP
+        MODE1_LOOP
+        adds TMP, PALETTE
+        ldm TMP, {TMP, PAIR}
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        movs TMP, 0x0F
+        str WRBIT, [LCD, 124]
+        str PAIR, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        ands TMP, TMP, COLOR
+        str WRBIT, [LCD, 124]
+    
+        lsls TMP, 3
+        adds TMP, PALETTE
+        ldm TMP, {TMP, PAIR}
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        ldm SCRBUF, {COLOR} // load next 4 bytes
+        str WRBIT, [LCD, 124]
+        str PAIR, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        mov TMP, CLEAR
+        cmp END, SCRBUF
+        str WRBIT, [LCD, 124]
+    bne mode1Loop // if scrbuf < end, loop
+
+    pop {r4, r5}
+    mov r8, r4
+    mov r9, r5
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode2.s
+++ b/Pokitto/POKITTO_HW/asm/mode2.s
@@ -1,0 +1,119 @@
+# mode2.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode2
+
+# void updateMode2(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"))
+.func updateMode2
+PALETTE .req r0
+SCRBUF .req r1
+
+# locals
+LCD         .req r2
+C           .req r3
+T           .req r4
+X           .req r5
+SCANLINE    .req r6
+byte        .req r7
+Y           .req r8
+WRBIT       .req r9
+
+.macro MODE2_LOOP
+    ldm SCANLINE!, {C}
+    str C, [LCD]
+    str T, [LCD, 124]
+    movs C, 252
+    str T, [LCD, C]
+    str T, [LCD, 124]
+    subs X, 1
+    str T, [LCD, C]
+.endm
+
+updateMode2:
+    push {r4-r7, lr}
+    mov r4, r8
+    mov r5, r9
+    mov r6, r10
+    push {r4-r6}
+    sub sp, 110*4
+    
+    mov SCANLINE, sp
+    ldr T, =1<<12
+    ldr LCD, =0xA0002188
+    mov WRBIT, T
+    ldr T, =0
+    mov Y, T
+    
+    
+    mode2OuterLoop:
+
+        movs X, 110
+        mode2InnerLoopA:
+
+            ldrb BYTE, [SCRBUF]
+            movs T, 15
+            lsrs C, BYTE, 4
+            ands BYTE, T
+        
+            lsls C, 1
+            ldrh T, [PALETTE, C]
+            lsls T, 3
+            str T, [LCD]
+            mov C, WRBIT
+            str C, [LCD, 124]
+            stm SCANLINE!, {T}
+            movs T, 252
+            str C, [LCD, T]
+            str C, [LCD, 124]
+            lsls BYTE, 1
+            str C, [LCD, T]
+            
+            ldrh T, [PALETTE, BYTE]
+            lsls T, 3
+            str T, [LCD]
+            mov C, WRBIT
+            str C, [LCD, 124]
+            stm SCANLINE!, {T}
+            movs T, 252
+            str C, [LCD, T]
+            str C, [LCD, 124]
+            adds SCRBUF, 1
+            str C, [LCD, T]
+            
+            subs X, 2
+        bne mode2InnerLoopA
+    
+        mov SCANLINE, sp
+        movs X, 110
+        mov T, WRBIT
+        mode2InnerLoopB:
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+        bne mode2InnerLoopB
+    
+        mov SCANLINE, sp
+        movs T, 1
+        movs C, 88
+        add Y, T
+        cmp Y, C
+    bne mode2OuterLoop
+
+    add sp, 110*4
+    pop {r4-r6}
+    mov r8, r4
+    mov r9, r5
+    mov r10, r6
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode2c.s
+++ b/Pokitto/POKITTO_HW/asm/mode2c.s
@@ -1,0 +1,127 @@
+# mode2c.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode2Clear
+
+# void updateMode2Clear(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"), int clear)
+.func updateMode2Clear
+PALETTE .req r0
+SCRBUF .req r1
+
+# locals
+LCD         .req r2
+C           .req r3
+T           .req r4
+X           .req r5
+SCANLINE    .req r6
+byte        .req r7
+Y           .req r8
+WRBIT       .req r9
+CLEAR       .req r10
+
+.macro MODE2_LOOP
+    ldm SCANLINE!, {C}
+    str C, [LCD]
+    str T, [LCD, 124]
+    movs C, 252
+    str T, [LCD, C]
+    str T, [LCD, 124]
+    subs X, 1
+    str T, [LCD, C]
+.endm
+
+updateMode2Clear:
+    push {r4-r7, lr}
+    mov r4, r8
+    mov r5, r9
+    mov r6, r10
+    push {r4-r6}
+    sub sp, 110*4
+    
+    lsls T, r2, 4
+    orrs r2, T
+    mov CLEAR, r2
+    
+    mov SCANLINE, sp
+    ldr T, =1<<12
+    ldr LCD, =0xA0002188
+    mov WRBIT, T
+    ldr T, =0
+    mov Y, T
+    
+    
+    mode2OuterLoop:
+
+        movs X, 110
+        mode2InnerLoopA:
+
+            ldrb BYTE, [SCRBUF]
+            mov T, CLEAR
+            strb T, [SCRBUF]
+            
+            movs T, 15
+            lsrs C, BYTE, 4
+            ands BYTE, T
+        
+            lsls C, 1
+            ldrh T, [PALETTE, C]
+            lsls T, 3
+            str T, [LCD]
+            mov C, WRBIT
+            str C, [LCD, 124]
+            stm SCANLINE!, {T}
+            movs T, 252
+            str C, [LCD, T]
+            str C, [LCD, 124]
+            lsls BYTE, 1
+            str C, [LCD, T]
+            
+            ldrh T, [PALETTE, BYTE]
+            lsls T, 3
+            str T, [LCD]
+            mov C, WRBIT
+            str C, [LCD, 124]
+            stm SCANLINE!, {T}
+            movs T, 252
+            str C, [LCD, T]
+            str C, [LCD, 124]
+            adds SCRBUF, 1
+            str C, [LCD, T]
+            
+            subs X, 2
+        bne mode2InnerLoopA
+    
+        mov SCANLINE, sp
+        movs X, 110
+        mov T, WRBIT
+        mode2InnerLoopB:
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+            MODE2_LOOP
+        bne mode2InnerLoopB
+    
+        mov SCANLINE, sp
+        movs T, 1
+        movs C, 88
+        add Y, T
+        cmp Y, C
+    bne mode2OuterLoop
+
+    add sp, 110*4
+    pop {r4-r6}
+    mov r8, r4
+    mov r9, r5
+    mov r10, r6
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode64.s
+++ b/Pokitto/POKITTO_HW/asm/mode64.s
@@ -1,0 +1,80 @@
+# mode64.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode64
+
+# void updateMode64(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"))
+.func updateMode64
+PALETTE .req r0
+SCRBUF .req r1
+
+# locals
+LCD .req r2
+WRBIT .req r3
+COLOR .req r4
+TMP .req r5
+CLR .req r6
+END .req r7
+
+updateMode64:
+    push {r4-r7, lr}
+    ldr LCD,   =0xA0002188
+    ldr WRBIT, =1<<12
+    ldr CLR,   =252
+    ldr END, =110*176+4
+    adds END, SCRBUF
+    
+    ldm SCRBUF!, {COLOR}
+    lsls TMP, COLOR, 24
+    mode64loop:
+        lsrs COLOR, COLOR, 8
+        lsrs TMP, TMP, 23
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        lsls TMP, COLOR, 24
+        lsrs COLOR, COLOR, 8
+        lsrs TMP, TMP, 23
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str WRBIT, [LCD, 124]
+        
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        lsls TMP, COLOR, 24
+        lsrs TMP, TMP, 23
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str WRBIT, [LCD, 124]
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        lsrs COLOR, COLOR, 8
+        lsls TMP, COLOR, 1
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str WRBIT, [LCD, 124]
+        
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        ldm SCRBUF!, {COLOR}
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        lsls TMP, COLOR, 24
+        cmp SCRBUF, END
+        str WRBIT, [LCD, 124]
+        
+    bne mode64loop
+    
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/mode64c.s
+++ b/Pokitto/POKITTO_HW/asm/mode64c.s
@@ -1,0 +1,140 @@
+# mode64c.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global updateMode64Clear
+
+# void updateMode64Clear(uint32_t* PALETTE asm("r0"), uint8_t* SCRBUF asm("r1"), int clear)
+.func updateMode64Clear
+PALETTE .req r0
+SCRBUF .req r1
+
+# locals
+LCD .req r2
+WRBIT .req r3
+COLOR .req r4
+TMP .req r5
+CLR .req r6
+END .req r7
+CLEAR .req r8
+
+updateMode64Clear:
+    push {r4-r7, lr}
+    mov r4, r8
+    push {r4}
+    
+    lsls TMP, r2, 16
+    orrs r2, TMP
+    lsls TMP, r2, 8
+    orrs r2, TMP
+    
+    mov CLEAR, r2
+    ldr LCD,   =0xA0002188
+    ldr WRBIT, =1<<12
+    ldr CLR,   =252
+    ldr END, =110*176
+    adds END, SCRBUF
+    
+    ldm SCRBUF, {COLOR}
+    mov TMP, CLEAR
+    stm SCRBUF!, {TMP}
+    lsls TMP, COLOR, 24
+    mode64loop:
+        lsrs COLOR, COLOR, 8
+        lsrs TMP, TMP, 23
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        lsls TMP, COLOR, 24
+        lsrs COLOR, COLOR, 8
+        lsrs TMP, TMP, 23
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str WRBIT, [LCD, 124]
+        
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        lsls TMP, COLOR, 24
+        lsrs TMP, TMP, 23
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str WRBIT, [LCD, 124]
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        lsrs COLOR, COLOR, 8
+        lsls TMP, COLOR, 1
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        ldrh TMP, [PALETTE, TMP]
+        lsls TMP, 3
+        str WRBIT, [LCD, 124]
+        
+        str TMP, [LCD, 0]
+        str WRBIT, [LCD, CLR]
+        ldm SCRBUF, {COLOR}
+        mov TMP, CLEAR
+        stm SCRBUF!, {TMP}
+        str WRBIT, [LCD, 124]
+        str WRBIT, [LCD, CLR]
+        lsls TMP, COLOR, 24
+        cmp SCRBUF, END
+        str WRBIT, [LCD, 124]
+        
+    bne mode64loop
+
+    lsrs COLOR, COLOR, 8
+    lsrs TMP, TMP, 23
+    ldrh TMP, [PALETTE, TMP]
+    lsls TMP, 3
+    str TMP, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+    lsls TMP, COLOR, 24
+    lsrs COLOR, COLOR, 8
+    lsrs TMP, TMP, 23
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, CLR]
+    ldrh TMP, [PALETTE, TMP]
+    lsls TMP, 3
+    str WRBIT, [LCD, 124]
+    
+    str TMP, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+    lsls TMP, COLOR, 24
+    lsrs TMP, TMP, 23
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, CLR]
+    ldrh TMP, [PALETTE, TMP]
+    lsls TMP, 3
+    str WRBIT, [LCD, 124]
+    str TMP, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+    lsrs COLOR, COLOR, 8
+    lsls TMP, COLOR, 1
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, CLR]
+    ldrh TMP, [PALETTE, TMP]
+    lsls TMP, 3
+    str WRBIT, [LCD, 124]
+    
+    str TMP, [LCD, 0]
+    str WRBIT, [LCD, CLR]
+
+    pop {r4}
+
+    str WRBIT, [LCD, 124]
+    str WRBIT, [LCD, CLR]
+
+    mov r8, r4
+
+    str WRBIT, [LCD, 124]
+    
+    pop {r4-r7, pc}
+    
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/pixelCopy.s
+++ b/Pokitto/POKITTO_HW/asm/pixelCopy.s
@@ -1,0 +1,70 @@
+# pixelCopy.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global pixelCopy
+.type   pixelCopy,%function
+# void pixelCopy(uint8_t* dest, uint8_t* src, int count)
+.func pixelCopy
+DEST .req r0
+SRC .req r1
+COUNT .req r2
+RECOLOR .req r3
+OFFSET .req r6
+TMP .req r5
+TMP2 .req r4
+
+.macro COPY
+    ldrb TMP2, [SRC, OFFSET]
+    cmp TMP2, 0
+    beq 1f
+        adds TMP2, RECOLOR
+        strb TMP2, [DEST, OFFSET]
+    1:
+    adds OFFSET, 1
+.endm
+
+pixelCopy:
+    push {r4-r6, lr}
+    ldr OFFSET, =0
+    
+    pcLoop:
+    // if( count == 0 ) return;
+    cmp COUNT, 0
+    beq pcEnd
+    
+    lsls TMP, COUNT, 32-3
+    lsrs TMP, 32-3
+    // if COUNT&7 == 0
+    bne notEight
+        movs TMP, 8
+    notEight:
+    // count -= (COUNT&7)
+    subs COUNT, TMP
+
+    // tmp = 8 * 12 - (COUNT&7) * 12
+    movs TMP2, 12
+    muls TMP, TMP2
+    movs TMP2, 8*12
+    subs TMP, TMP2, TMP
+    
+    // tmp += pcStart
+    ldr TMP2, =pcStart+1
+    adds TMP, TMP2
+    bx TMP
+    pcStart:
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+    b pcLoop
+    
+    pcEnd:
+    pop {r4-r6, pc}
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/pixelCopyMirror.s
+++ b/Pokitto/POKITTO_HW/asm/pixelCopyMirror.s
@@ -1,0 +1,69 @@
+# pixelCopyMirror.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global pixelCopyMirror
+.type   pixelCopyMirror,%function
+# void pixelCopyMirror(uint8_t* dest, uint8_t* src, int count)
+.func pixelCopyMirror
+DEST .req r0
+SRC .req r1
+COUNT .req r2
+RECOLOR .req r3
+TMP .req r5
+TMP2 .req r4
+
+.macro COPY
+    subs SRC, 1
+    ldrb TMP2, [SRC]
+    cmp TMP2, 0
+    beq 1f
+        adds TMP2, RECOLOR
+        strb TMP2, [DEST]
+    1:
+    adds DEST, 1
+.endm
+
+pixelCopyMirror:
+    push {r4-r6, lr}
+    adds SRC, COUNT
+    pcLoop:
+    // if( count == 0 ) return;
+    cmp COUNT, 0
+    beq pcEnd
+    
+    lsls TMP, COUNT, 32-3
+    lsrs TMP, 32-3
+    // if COUNT&7 == 0
+    bne notEight
+        movs TMP, 8
+    notEight:
+    // count -= (COUNT&7)
+    subs COUNT, TMP
+
+    // tmp = 8 * 7 - (COUNT&7) * 7
+    movs TMP2, 7*2
+    muls TMP, TMP2
+    movs TMP2, 8*7*2
+    subs TMP, TMP2, TMP
+    
+    // tmp += pcStart
+    ldr TMP2, =pcStart+1
+    adds TMP, TMP2
+    bx TMP
+    pcStart:
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+    b pcLoop
+    
+    pcEnd:
+    pop {r4-r6, pc}
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/pixelCopySolid.s
+++ b/Pokitto/POKITTO_HW/asm/pixelCopySolid.s
@@ -1,0 +1,75 @@
+# pixelCopySolid.s by FManga
+# This code is from the PokittoLib and is therefore under the BSD License.
+
+.thumb
+.syntax unified
+.global pixelCopySolid
+.type   pixelCopySolid,%function
+# void pixelCopySolid(uint8_t* dest, uint8_t* src, int count)
+.func pixelCopySolid
+DEST .req r0
+SRC .req r1
+COUNT .req r2
+RECOLOR .req r3
+OFFSET .req r6
+TMP .req r5
+TMP2 .req r4
+
+.macro COPY
+    ldrb TMP2, [SRC, OFFSET]
+    adds TMP2, RECOLOR
+    strb TMP2, [DEST, OFFSET]
+    adds OFFSET, 1
+.endm
+
+pixelCopySolid:
+    push {r4-r6, lr}
+    ldr OFFSET, =0
+    
+    pcLoop:
+    // if( count == 0 ) return;
+    cmp COUNT, 0
+    beq pcEnd
+    
+    lsls TMP, COUNT, 32-4
+    lsrs TMP, 32-4
+    // if COUNT&0xF == 0
+    bne notEight
+        movs TMP, 16
+    notEight:
+    // count -= (COUNT&0xF)
+    subs COUNT, TMP
+
+    // tmp = 16 * 8 - (COUNT&0xF) * 8
+    lsls TMP, 3
+    movs TMP2, 16 * 8
+    subs TMP, TMP2, TMP
+    
+    // tmp += pcStart
+    ldr TMP2, =pcStart+1
+    adds TMP, TMP2
+    bx TMP
+    pcStart:
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+        COPY
+    b pcLoop
+    
+    pcEnd:
+    pop {r4-r6, pc}
+.pool
+.endfunc

--- a/Pokitto/POKITTO_HW/asm/unlz4.s
+++ b/Pokitto/POKITTO_HW/asm/unlz4.s
@@ -1,0 +1,67 @@
+.syntax             unified
+                    .cpu                cortex-m0
+                    .thumb
+
+                    .func               unlz4
+                    .global             unlz4,unlz4_len
+                    .type               unlz4,%function
+                    .type               unlz4_len,%function
+
+                    .thumb_func
+unlz4:              ldrh                r2,[r0]             /* get length of compressed data */
+                    adds                r0,r0,#2            /* advance source pointer */
+
+                    .thumb_func
+unlz4_len:          push                {r4-r6,lr}          /* save r4, r5, r6 and return-address */
+
+                    adds                r5,r2,r0            /* point r5 to end of compressed data */
+
+getToken:           ldrb                r6,[r0]             /* get token */
+                    adds                r0,r0,#1            /* advance source pointer */
+                    lsrs                r4,r6,#4            /* get literal length, keep token in r6 */
+                    beq                 getOffset           /* jump forward if there are no literals */
+                    bl                  getLength           /* get length of literals */
+                    movs                r2,r0               /* point r2 to literals */
+                    bl                  copyData            /* copy literals (r2=src, r1=dst, r4=len) */
+                    movs                r0,r2               /* update source pointer */
+getOffset:          ldrb                r3,[r0,#0]          /* get match offset's low byte */
+                    subs                r2,r1,r3            /* subtract from destination; this will become the match position */
+                    ldrb                r3,[r0,#1]          /* get match offset's high byte */
+                    lsls                r3,r3,#8            /* shift to high byte */
+                    subs                r2,r2,r3            /* subtract from match position */
+                    adds                r0,r0,#2            /* advance source pointer */
+                    lsls                r4,r6,#28           /* get rid of token's high 28 bits */
+                    lsrs                r4,r4,#28           /* move the 4 low bits back where they were */
+                    bl                  getLength           /* get length of match data */
+                    adds                r4,r4,#4            /* minimum match length is 4 bytes */
+                    bl                  copyData            /* copy match data (r2=src, r1=dst, r4=len) */
+                    cmp                 r0,r5               /* check if we've reached the end of the compressed data */
+                    blt                 getToken            /* if not, go get the next token */
+                    pop                 {r4-r6,pc}          /* restore r4, r5 and r6, then return */
+
+                    .thumb_func
+getLength:          cmp                 r4,#0x0f            /* if length is 15, then more length info follows */
+                    bne                 gotLength           /* jump forward if we have the complete length */
+getLengthLoop:      ldrb                r3,[r0]             /* read another byte */
+                    adds                r0,r0,#1            /* advance source pointer */
+                    adds                r4,r4,r3            /* add byte to length */
+                    cmp                 r3,#0xff            /* check if end reached */
+                    beq                 getLengthLoop       /* if not, go round loop */
+gotLength:          bx                  lr                  /* return */
+
+                    .thumb_func
+copyData:           rsbs                r4,r4,#0            /* index = -length */
+                    subs                r2,r2,r4            /* point to end of source */
+                    subs                r1,r1,r4            /* point to end of destination */
+
+copyDataLoop:       ldrb                r3,[r2,r4]          /* read byte from source_end[-index] */
+                    strb                r3,[r1,r4]          /* store byte in destination_end[-index] */
+                    adds                r4,r4,#1            /* increment index */
+                    bne                 copyDataLoop        /* keep going until index wraps to 0 */
+                    bx                  lr                  /* return */
+
+                    .size               unlz4,.-unlz4
+
+                    .endfunc
+                    
+                    

--- a/Pokitto/POKITTO_LIBS/FixMath/fix16.h
+++ b/Pokitto/POKITTO_LIBS/FixMath/fix16.h
@@ -1,8 +1,6 @@
 #ifndef __libfixmath_fix16_h__
 #define __libfixmath_fix16_h__
 
-#include "Pokitto_settings.h"
-
 /** OPTIONS **/
 #define FIXMATH_SIN_LUT
 

--- a/Pokitto/POKITTO_LIBS/MicroPython/PythonBindings.cpp
+++ b/Pokitto/POKITTO_LIBS/MicroPython/PythonBindings.cpp
@@ -198,16 +198,9 @@ void Pok_Display_blitFrameBuffer(int16_t x, int16_t y, int16_t w, int16_t h, boo
 }
 
 void Pok_Display_setSprite(uint8_t index, int16_t x, int16_t y, int16_t w, int16_t h, int16_t invisiblecol_, uint8_t *buffer, uint16_t* palette16x16bit, bool doResetDirtyRect) {
-#if (POK_SCREENMODE == MODE_HI_4COLOR)
-    Display::invisiblecolor = (uint8_t)invisiblecol_;
-    Display::setSprite(index, buffer, palette16x16bit, x, y, w, h, doResetDirtyRect );
-#endif
 }
 
 void Pok_Display_setSpritePos(uint8_t index, int16_t x, int16_t y) {
-#if (POK_SCREENMODE == MODE_HI_4COLOR)
-    Display::setSpritePos(index, x, y);
-#endif
 }
 
 uint16_t POK_game_display_RGBto565(uint8_t r, uint8_t g, uint8_t b) {
@@ -220,25 +213,19 @@ void POK_game_display_setPalette(uint16_t* paletteArray, int16_t len) {
 }
 
 void Pok_Display_setClipRect(int16_t x, int16_t y, int16_t w, int16_t h) {
-#if (POK_SCREENMODE == MODE_HI_4COLOR)
-    if(h == 0)
-        Display::setClipRect(0, 0, LCDWIDTH, LCDHEIGHT);  // Remove clip rect
-    else
-        Display::setClipRect(x, y, w, h);  // Set clip rect
-#endif
 }
 
 // Draw the screen surface immediately to the display. Do not care about fps limits. Do not run event loops etc.
 void Pok_Display_update(bool useDirectMode, uint8_t x, uint8_t y, uint8_t w, uint8_t h)
 {
-    Display::update(useDirectMode, x, y, w, h);
+    Display::update(useDirectMode);
 }
 
 // Run the event loops, audio loops etc. Draws the screen when the fps limit is reached and returns true.
 bool Pok_Core_update(bool useDirectMode, uint8_t x, uint8_t y, uint8_t w, uint8_t h )
 {
 
-    bool ret = Core::update(useDirectMode, x, y, w, h);
+    bool ret = Core::update(useDirectMode);
     //printf("update, %d ms\n", Core::getTime()-s);
     return ret;
 }

--- a/Pokitto/Pokitto_settings.h
+++ b/Pokitto/Pokitto_settings.h
@@ -34,9 +34,8 @@
 */
 /**************************************************************************/
 
-
-#ifndef POKITTO_SETTINGS_H
-#define POKITTO_SETTINGS_H
+#pragma once
+#include <stdint.h>
 
 #include "My_settings.h"
 
@@ -115,14 +114,14 @@
     #define POK_ENABLE_SYNTH PROJ_ENABLE_SYNTH
 #endif // PROJ_ENABLE_SYNTH
 
-#define HIGH_RAM_OFF 0 // SRAM1/SRAM2 are at the default setting
-#define HIGH_RAM_ON  1 // SRAM1/SRAM2 are enabled and free for use
-#define HIGH_RAM_MUSIC 2 // SRAM1/SRAM2 are enabled and used by music
+#define HIGH_RAM_OFF     0 // SRAM1/SRAM2 are at the default setting
+#define HIGH_RAM_ON      1 // SRAM1/SRAM2 are enabled and free for use
+#define HIGH_RAM_MUSIC   2 // SRAM1/SRAM2 are enabled and used by music
 
 #ifndef PROJ_HIGH_RAM
-#define POK_HIGH_RAM HIGH_RAM_OFF
+    #define POK_HIGH_RAM HIGH_RAM_OFF
 #else
-#define POK_HIGH_RAM PROJ_HIGH_RAM
+    #define POK_HIGH_RAM PROJ_HIGH_RAM
 #endif
 
 /** CONSOLE **/
@@ -137,351 +136,153 @@
 #define POK_SHOW_VOLUME 0 // volumebar drawn after console if enabled
 #define VOLUMEBAR_TIMEOUT 10 // frames before disappearing
 
-/** PROJECT LIBRARY TYPE **/
-// Tiled mode can NOT be buffered mode (fast mode, arduboy mode, gamebuino mode etc)
-#if PROJ_TILEDMODE > 0
-    #define POK_TILEDMODE 1
-    #ifdef PROJ_TILEWIDTH
-        #define POK_TILE_W PROJ_TILEWIDTH
-    #else
-        #define POK_TILE_W 11
-    #endif // PROJ_TILEWIDTH
-    #if POK_TILE_W == 11
-        #define POK_TILES_X 20
-        #define LCDWIDTH 220
-    #elif POK_TILE_W == 12
-        #define POK_TILES_X 18
-        #define LCDWIDTH 216
-    #elif POK_TILE_W == 8
-        #define POK_TILES_X 27
-        #define LCDWIDTH 216
-    #elif POK_TILE_W == 32
-        #define POK_TILES_X 6
-        #define LCDWIDTH 220
-    #elif POK_TILE_W == 10
-        #define POK_TILES_X 22
-        #define LCDWIDTH 220
-    #elif POK_TILE_W == 14
-        #define POK_TILES_X 15
-        #define LCDWIDTH 210
-    #endif
-    #ifdef PROJ_TILEHEIGHT
-        #define POK_TILE_H PROJ_TILEHEIGHT
-    #else
-        #define POK_TILE_H 11
-    #endif // PROJ_TILEHEIGHT
-    #if POK_TILE_H == 11
-        #define POK_TILES_Y 16
-        #define LCDHEIGHT 176
-    #elif POK_TILE_H == 12
-        #define POK_TILES_Y 14
-        #define LCDHEIGHT 168
-    #elif POK_TILE_H == 8
-        #define POK_TILES_Y 22
-        #define LCDHEIGHT 176
-    #elif POK_TILE_H == 32
-        #define POK_TILES_Y 5
-        #define LCDHEIGHT 176
-    #elif POK_TILE_H == 10
-        #define POK_TILES_Y 17
-        #define LCDHEIGHT 170
-    #elif POK_TILE_H == 14
-        #define POK_TILES_Y 12
-        #define LCDHEIGHT 168
-    #endif
-#else
-#if PROJ_GAMEBUINO > 0
-    #define POK_GAMEBUINO_SUPPORT PROJ_GAMEBUINO // Define true to support Gamebuino library calls
-    #define PROJ_SCREENMODE MODE_GAMEBUINO_16COLOR
-    #define POK_STRETCH 1
-    #define PICOPALETTE 0
-    #define POK_COLORDEPTH 4
-    #define ENABLE_GUI 1
-#else
-    #ifndef ENABLE_GUI
-        #define ENABLE_GUI 0
-    #endif
-    #if PROJ_ARDUBOY > 0
-        #define POK_ARDUBOY_SUPPORT PROJ_ARDUBOY // Define true to support Arduboy library calls
-        #define PROJ_SCREENMODE MODE_ARDUBOY_16COLOR
-        #define POK_COLORDEPTH 1
-        #define POK_STRETCH 1
-        #define POK_FPS 20
-        #define PICOPALETTE 0
-    #else
-        #if PROJ_RBOY > 0
-            #define PROJ_SCREENMODE MODE_GAMEBUINO_16COLOR
-            #define POK_COLORDEPTH 1
-            #define POK_STRETCH 0
-            #define POK_FPS 40
-            #define PICOPALETTE 0
-        #else
-            #if PROJ_GAMEBOY > 0
-            #define PROJ_SCREENMODE MODE_GAMEBOY
-            #define POK_COLORDEPTH 2
-            #define POK_STRETCH 0
-            #define POK_FPS 6
-            #define PICOPALETTE 0
-            #else
-                #define POK_GAMEBUINO_SUPPORT 0
-                #define POK_GAMEBOY_SUPPORT 0
-                #define POK_ARDUBOY_SUPPORT 0
-                #define PICOPALETTE 0
-                #define POK_COLORDEPTH 4
-            #endif // PROJ_GAMEBOY
-        #endif // PROJ_RBOY
-    #endif // PROJ_ARDUBOY
-#endif // PROJ_GAMEBUINO
-#endif // PROJ_TILEDMODE
+/** SCREEN CONFIGURATION **/
+#ifndef PROJ_PERSISTENCE
+    #define PROJ_PERSISTENCE true
+#endif
+inline constexpr bool POK_PERSISTENCE = PROJ_PERSISTENCE;
 
+#ifndef PROJ_CLEAR_SCREEN
+    #define PROJ_CLEAR_SCREEN 0
+#endif
+inline constexpr uint32_t POK_CLEAR_SCREEN = PROJ_CLEAR_SCREEN;
 
-/** SCREEN MODES TABLE -- DO NOT CHANGE THESE **/
+#ifndef PROJ_FPS
+    #define PROJ_FPS 60
+#endif
+inline constexpr uint32_t POK_FPS = PROJ_FPS;
+inline constexpr uint32_t POK_FRAMEDURATION = 1000 / PROJ_FPS;
 
-#define POK_LCD_W 220 //<- do not change !!
-#define POK_LCD_H 176 //<- do not change !!
+inline constexpr uint32_t R_MASK = 0xF800;
+inline constexpr uint32_t G_MASK = 0x07E0;
+inline constexpr uint32_t B_MASK = 0x001F;
 
-#define MODE_NOBUFFER               0   //Size: 0
-#define BUFSIZE_NOBUFFER            0
-#define MODE_HI_4COLOR              1   //Size: 9680
-#define BUFSIZE_HI_4                9680
-#define MODE_FAST_16COLOR           2   //Size: 4840
-#define BUFSIZE_FAST_16             4840
-#define MODE_GAMEBUINO_16COLOR      4   //Size: 2016
-#define BUFSIZE_GAMEBUINO_16        2016
-#define MODE_ARDUBOY_16COLOR        5   //Size: 4096
-#define BUFSIZE_ARDUBOY_16          4096
-#define MODE_HI_MONOCHROME          6   //Size: 4840
-#define BUFSIZE_HI_MONO             4840
-#define MODE_HI_GRAYSCALE           7   //Size: 9680
-#define BUFSIZE_HI_GS               9680
-#define MODE_GAMEBOY                8
-#define BUFSIZE_GAMEBOY             5760
-#define MODE_UZEBOX                 9
-#define MODE_TVOUT                  10
-#define MODE_LAMENES                11
-#define BUFSIZE_LAMENES             7680
-#define MODE_256_COLOR              12
-#define BUFSIZE_MODE_12              4176 // 72 x 58
-#define MODE13                      13
-#define BUFSIZE_MODE13              9680 // 110*88
-#define MIXMODE                     32
-#define BUFSIZE_MIXMODE             9680 // 110*88
-#define MODE64                      64
-#define BUFSIZE_MODE64              19360 // 110*176
-#define MODE14                      14
-#define BUFSIZE_MODE14              14520
-#define MODE15                      15
-#define BUFSIZE_MODE15              19360
-// Tiled modes
-#define MODE_TILED_1BIT             1001
-#define MODE_TILED_8BIT             1002
+inline constexpr uint32_t POK_LCD_W = 220;
+inline constexpr uint32_t POK_LCD_H = 176;
 
-
-    #define R_MASK  0xF800
-    #define G_MASK  0x7E0
-    #define B_MASK  0x1F
+#define MODE_NOBUFFER            0
+#define MODE_HI_4COLOR           1
+#define MODE_FAST_16COLOR        2
+#define MODE13                   13
+#define MODE15                   15
+#define MIXMODE                  32
+#define TASMODE                  42
+#define MODE64                   64
 
 /** SCREENMODE - USE THIS SELECTION FOR YOUR PROJECT **/
-
-#if POK_TILEDMODE > 0
-    #ifndef PROJ_TILEBITDEPTH
-        #define PROJ_TILEBITDEPTH 8 //default tiling mode is 256 color mode!
-    #endif // PROJ_TILEBITDEPTH
-    #if PROJ_TILEBITDEPTH == 1
-        #define POK_SCREENMODE MODE_TILED_1BIT
-        #define POK_COLORDEPTH 1
-    #else
-        #define POK_SCREENMODE MODE_TILED_8BIT
-        #define POK_COLORDEPTH 8
-    #endif // PROJ_TILEBITDEPTH
-#else
 #ifndef PROJ_SCREENMODE
-    #undef POK_COLORDEPTH
-    #ifdef PROJ_HIRES
-        #if PROJ_HIRES > 0
-            #define POK_SCREENMODE MODE_HI_4COLOR
-            #undef POK_COLORDEPTH
-            #define POK_COLORDEPTH 2
-        #elif PROJ_HICOLOR > 0
-            #define POK_SCREENMODE MODE_256_COLOR
-            #undef POK_COLORDEPTH
-            #define POK_COLORDEPTH 8
-        #else
-            #define POK_SCREENMODE MODE_FAST_16COLOR
-            #undef POK_COLORDEPTH
-            #define POK_COLORDEPTH 4
-        #endif // PROJ_HIRES
+    #if defined(PROJ_HIRES) &&  PROJ_HIRES > 0
+        #define PROJ_SCREENMODE MODE_HI_4COLOR
+    #elif defined(PROJ_HICOLOR) && PROJ_HICOLOR > 0
+        #define PROJ_SCREENMODE MODE13
+    #elif defined(PROJ_TASMODE) && PROJ_TASMODE > 0
+        #define PROJ_SCREENMODE TASMODE
+    #elif defined(PROJ_MODE13) && PROJ_MODE13 > 0
+        #define PROJ_SCREENMODE MODE13
+    #elif defined(PROJ_MIXMODE) && PROJ_MIXMODE > 0
+        #define PROJ_SCREENMODE MIXMODE
+    #elif defined(PROJ_MODE64) && PROJ_MODE64 > 0
+        #define PROJ_SCREENMODE MODE64
     #else
-        #define POK_SCREENMODE MODE_FAST_16COLOR
-        #define POK_COLORDEPTH 4
-    #endif // PROJ_HIRES
-#else
-    #define POK_SCREENMODE PROJ_SCREENMODE
-#endif
+        #define PROJ_SCREENMODE MODE_FAST_16COLOR
+    #endif
 #endif // POK_TILEDMODE
 
-
-#if PROJ_SCREENMODE == 1
-    #undef POK_SCREENMODE //get rid of warnings
-    #define POK_SCREENMODE MODE_HI_4COLOR
-    #undef POK_COLORDEPTH
-    #define POK_COLORDEPTH 2
-    #define LCDWIDTH POK_LCD_W
-    #define LCDHEIGHT POK_LCD_H
+#if PROJ_SCREENMODE == MODE_NOBUFFER
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_NOBUFFER
+    #define PROJ_COLORDEPTH 8
 #endif
 
-
-#if PROJ_MODE13 > 0 || PROJ_SCREENMODE == 13
-    #undef POK_SCREENMODE //get rid of warnings
-    #undef POK_COLORDEPTH
-    #undef POK_FPS
-    #define POK_SCREENMODE MODE13
-    #define POK_COLORDEPTH 8
-    #define POK_STRETCH 0
-    #define POK_FPS 30
-#endif
-
-#if PROJ_MIXMODE > 0
-    #undef POK_SCREENMODE //get rid of warnings
-    #undef POK_COLORDEPTH
-    #undef POK_FPS
-    #define POK_SCREENMODE MIXMODE
-    #define POK_COLORDEPTH 8
-    #define POK_STRETCH 0
-    #define POK_FPS 30
-#endif
-
-
-#if PROJ_MODE64 > 0 || PROJ_SCREENMODE == 64
-    #undef POK_SCREENMODE //get rid of warnings
-    #undef POK_COLORDEPTH
-    #undef POK_FPS
-    #define POK_SCREENMODE MODE64
-    #define POK_COLORDEPTH 8
-    #define POK_STRETCH 0
-    #define POK_FPS 30
-#endif
-
-#if PROJ_MODE14 > 0 || PROJ_SCREENMODE == 14
-    #undef POK_SCREENMODE //get rid of warnings
-    #undef POK_COLORDEPTH
-    #undef POK_FPS
-    #define POK_SCREENMODE MODE14
-    #define POK_COLORDEPTH 3
-    #define POK_STRETCH 0
-    #define POK_FPS 30
-#endif
-#if PROJ_MODE15 > 0 || PROJ_SCREENMODE == 15
-    #undef POK_SCREENMODE //get rid of warnings
-    #undef POK_COLORDEPTH
-    #undef POK_FPS
-    #define POK_SCREENMODE MODE15
-    #define POK_COLORDEPTH 4
-    #define POK_STRETCH 0
-    #ifdef PROJ_FPS
-        #define POK_FPS PROJ_FPS
-    #else
-        #define POK_FPS 200
+#if PROJ_SCREENMODE == TASMODE
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_TASMODE
+    #define PROJ_COLORDEPTH 8
+    #ifndef PROJ_MAX_SPRITES
+        #define PROJ_MAX_SPRITES 100
     #endif
-    #define POK_BITFRAME 4840
+    #ifndef PROJ_TILEWIDTH
+        #define PROJ_TILE_W 16
+    #endif // PROJ_TILEWIDTH
+    #ifndef PROJ_TILEHEIGHT
+        #define PROJ_TILE_H 16
+    #endif // PROJ_TILEHEIGHT
+    inline constexpr uint32_t POK_TILE_W = PROJ_TILE_W;
+    inline constexpr uint32_t POK_TILE_H = PROJ_TILE_H;
 #endif
-/* DEFINE SCREENMODE AS THE MAXIMUM SCREEN SIZE NEEDED BY YOUR APP ... SEE SIZES LISTED ABOVE */
+
+#if PROJ_SCREENMODE == MODE_FAST_16COLOR
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_FAST_16COLOR
+    #define PROJ_COLORDEPTH 4
+    #define PROJ_LCDWIDTH 110
+    #define PROJ_LCDHEIGHT 88
+#endif
+
+#if PROJ_SCREENMODE == MODE13
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_MODE13
+    #define PROJ_COLORDEPTH 8
+    #define PROJ_LCDWIDTH 110
+    #define PROJ_LCDHEIGHT 88
+#endif
+
+#if PROJ_SCREENMODE == MODE15
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_MODE15
+    #define PROJ_COLORDEPTH 4
+#endif
+
+#if PROJ_SCREENMODE == MIXMODE
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_MIXMODE
+    #define PROJ_COLORDEPTH 8
+    #define PROJ_LCDWIDTH 110
+    #define PROJ_LCDHEIGHT 88
+#endif
+
+#if PROJ_SCREENMODE == MODE64
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_MODE64
+    #define PROJ_COLORDEPTH 8
+    #define PROJ_LCDWIDTH 110
+    #define PROJ_LCDHEIGHT 176
+#endif
+
+#if PROJ_SCREENMODE == MODE_HI_4COLOR || !defined(PROJ_SCREENBUFFERSIZE)
+    #define PROJ_SCREENBUFFERSIZE BUFSIZE_HI_4COLOR
+    #define PROJ_COLORDEPTH 2
+#endif
+
+#ifndef PROJ_LCDWIDTH
+    #define PROJ_LCDWIDTH POK_LCD_W
+#endif
+inline constexpr uint32_t LCDWIDTH = PROJ_LCDWIDTH;
+
+#ifndef PROJ_LCDHEIGHT
+    #define PROJ_LCDHEIGHT POK_LCD_H
+#endif
+inline constexpr uint32_t LCDHEIGHT = PROJ_LCDHEIGHT;
 
 /** AUTOMATIC COLOR DEPTH SETTING - DO NOT CHANGE **/
-#ifndef POK_COLORDEPTH
-    #define POK_COLORDEPTH 4 // 1...5 is valid
-#endif // POK_COLORDEPTH
+#ifndef PROJ_COLORDEPTH
+    #define PROJ_COLORDEPTH 4
+#endif // PROJ_COLORDEPTH
+inline constexpr uint32_t POK_COLORDEPTH = PROJ_COLORDEPTH;
 
-/** AUTOMATIC SCREEN BUFFER SIZE CALCULATION - DO NOT CHANGE **/
-#if POK_SCREENMODE == 0
-    #define POK_SCREENBUFFERSIZE 0
-    #define LCDWIDTH POK_LCD_W
-    #define LCDHEIGHT POK_LCD_H
-    #define POK_BITFRAME 0
-#elif POK_SCREENMODE == MODE_HI_MONOCHROME
-    #define POK_SCREENBUFFERSIZE POK_LCD_W*POK_LCD_H*POK_COLORDEPTH/8
-    #define LCDWIDTH POK_LCD_W
-    #define LCDHEIGHT POK_LCD_H
-    #define POK_BITFRAME 4840
-#elif POK_SCREENMODE == MODE_HI_4COLOR || POK_SCREENMODE == MODE_HI_GRAYSCALE
-    #define POK_SCREENBUFFERSIZE (POK_LCD_W*POK_LCD_H*POK_COLORDEPTH/4)
-    #define LCDWIDTH POK_LCD_W
-    #define LCDHEIGHT POK_LCD_H
-    #define POK_BITFRAME 4840
-#elif POK_SCREENMODE == MODE_FAST_16COLOR
-    #define POK_SCREENBUFFERSIZE (POK_LCD_W/2)*(POK_LCD_H/2)*POK_COLORDEPTH/8
-    #define XCENTER POK_LCD_W/4
-    #define YCENTER POK_LCD_H/4
-    #define LCDWIDTH 110
-    #define LCDHEIGHT 88
-    #define POK_BITFRAME 1210
-#elif POK_SCREENMODE == MODE_256_COLOR
-    #define POK_SCREENBUFFERSIZE 72*58
-    #define XCENTER 36
-    #define YCENTER 29
-    #define LCDWIDTH 72
-    #define LCDHEIGHT 58
-    #define POK_BITFRAME 72*58
-#elif POK_SCREENMODE == MODE_GAMEBUINO_16COLOR
-    #define POK_SCREENBUFFERSIZE (84/2)*(48/2)*POK_COLORDEPTH/8
-    #define LCDWIDTH 84
-    #define LCDHEIGHT 48
-    #define POK_BITFRAME 504
-#elif POK_SCREENMODE == MODE_ARDUBOY_16COLOR
-    #define POK_SCREENBUFFERSIZE (128/2)*(64/2)*POK_COLORDEPTH/8
-    #define LCDWIDTH 128
-    #define LCDHEIGHT 64
-    #define POK_BITFRAME 1024
-#elif POK_SCREENMODE == MODE_LAMENES
-    #define POK_SCREENBUFFERSIZE (128)*(120)*POK_COLORDEPTH/8
-    #define LCDWIDTH 128
-    #define LCDHEIGHT 120
-    #define POK_BITFRAME 1210
-#elif POK_SCREENMODE == MODE_GAMEBOY
-    #define POK_SCREENBUFFERSIZE (160)*(144)/4
-    #define LCDWIDTH 160
-    #define LCDHEIGHT 144
-    #define POK_BITFRAME 2880
-#elif POK_SCREENMODE == MODE13
-    #define POK_SCREENBUFFERSIZE 110*88
-    #define LCDWIDTH 110
-    #define LCDHEIGHT 88
-    #define POK_BITFRAME 110*88
-#elif POK_SCREENMODE == MIXMODE
-    #define POK_SCREENBUFFERSIZE 110*88
-    #define LCDWIDTH 110
-    #define LCDHEIGHT 88
-    #define POK_BITFRAME 110*88
-#elif POK_SCREENMODE == MODE64
-    #define POK_SCREENBUFFERSIZE 110*176
-    #define LCDWIDTH 110
-    #define LCDHEIGHT 176
-    #define POK_BITFRAME 110*176
-#elif POK_SCREENMODE == MODE14
-    #define POK_SCREENBUFFERSIZE 14520
-    #define LCDWIDTH 220
-    #define LCDHEIGHT 176
-    #define POK_BITFRAME 4840
-#elif POK_SCREENMODE == MODE15
-    #define POK_SCREENBUFFERSIZE 0x4BA0
-    #define LCDWIDTH 220
-    #define LCDHEIGHT 176
+inline constexpr uint32_t BUFSIZE_NOBUFFER = 0;
+inline constexpr uint32_t BUFSIZE_TASMODE = 220;
+inline constexpr uint32_t BUFSIZE_HI_4COLOR = ((POK_LCD_H+1)*POK_LCD_W)*POK_COLORDEPTH/8;
+inline constexpr uint32_t BUFSIZE_FAST_16COLOR = (((POK_LCD_H/2)+1)*POK_LCD_W/2)*POK_COLORDEPTH/8;
+inline constexpr uint32_t BUFSIZE_MODE13 = 110*88;
+inline constexpr uint32_t BUFSIZE_MODE15 = 0x4BA0;
+inline constexpr uint32_t BUFSIZE_MIXMODE = 110*88;
 
-#else
-    #define POK_SCREENBUFFERSIZE 0
-#endif // POK_SCREENMODE
-
-#ifndef POK_STRETCH
-    #define POK_STRETCH 1 // Stretch Gamebuino display
+#ifndef PROJ_SCREENBUFFERSIZE
+    #define PROJ_SCREENBUFFERSIZE 0
 #endif
+inline constexpr uint32_t POK_SCREENBUFFERSIZE = PROJ_SCREENBUFFERSIZE;
 
-#ifdef PROJ_FPS
-#define POK_FPS PROJ_FPS
+inline constexpr uint32_t XCENTER = LCDWIDTH / 2;
+inline constexpr uint32_t YCENTER = LCDHEIGHT / 2;
+
+#ifndef PROJ_PALETTE_SIZE
+    #define PROJ_PALETTE_SIZE 1<<PROJ_COLORDEPTH
 #endif
-#ifndef POK_FPS
-    #define POK_FPS 20
-#endif
-#define POK_FRAMEDURATION 1000/POK_FPS
+inline constexpr uint32_t PALETTE_SIZE = PROJ_PALETTE_SIZE;
 
 /** SCROLL TEXT VS. WRAP AROUND WHEN PRINTING **/
 #if PROJ_NO_AUTO_SCROLL
@@ -505,7 +306,6 @@
 #if PROJ_AUD_TRACKER > 0
     #define POK_AUD_TRACKER 1
 #endif
-
 
 #define POK_USE_EXT 0 // if extension port is in use or not
 
@@ -595,5 +395,4 @@
 #endif
 
 
-#endif // POKITTO_SETTINGS_H
 

--- a/Pokitto/Pokitto_settings.h
+++ b/Pokitto/Pokitto_settings.h
@@ -199,10 +199,10 @@ inline constexpr uint32_t POK_LCD_H = 176;
     #ifndef PROJ_MAX_SPRITES
         #define PROJ_MAX_SPRITES 100
     #endif
-    #ifndef PROJ_TILEWIDTH
+    #ifndef PROJ_TILE_W
         #define PROJ_TILE_W 16
     #endif // PROJ_TILEWIDTH
-    #ifndef PROJ_TILEHEIGHT
+    #ifndef PROJ_TILE_H
         #define PROJ_TILE_H 16
     #endif // PROJ_TILEHEIGHT
     inline constexpr uint32_t POK_TILE_W = PROJ_TILE_W;

--- a/Pokitto/mbed-pokitto/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/LPC11U68.ld
+++ b/Pokitto/mbed-pokitto/targets/cmsis/TARGET_NXP/TARGET_LPC11U6X/TOOLCHAIN_GCC_ARM/TARGET_LPC11U68/LPC11U68.ld
@@ -66,6 +66,7 @@ SECTIONS
         
         *(.text*)
         *(.rodata .rodata.*)
+        *(__global_locale)
         . = ALIGN(4);
         
         /* C++ constructors etc */

--- a/Pokitto/mbed-pokitto/targets/cmsis/core_cmFunc.h
+++ b/Pokitto/mbed-pokitto/targets/cmsis/core_cmFunc.h
@@ -423,7 +423,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
   return(result);
@@ -450,7 +450,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOf
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+    uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
   return(result);


### PR DESCRIPTION
Contains breaking changes. Projects will now need `-std=c++17` in the C++ compiler flags.
Might require further discussion in the forums.