### PR TITLE
printFPS declared as static

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoDisplay.h
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.h
@@ -448,7 +448,7 @@ public:
 #endif
 
 private:
-    void printFPS();
+    static void printFPS();
     static uint8_t m_mode;
     static uint8_t m_w,m_h; // store these for faster access when switching printing modes
     /** Pointer to screen buffer */


### PR DESCRIPTION
printFPS must declared as static since it's only called inside a static method.