### PR TITLE
Fixed solid copy in pixelCopySolid4BPP

### DIFF
--- a/Pokitto/POKITTO_CORE/TASMODE.cpp
+++ b/Pokitto/POKITTO_CORE/TASMODE.cpp
@@ -305,7 +305,7 @@ void pixelCopySolid4BPP(uint8_t *line, const uint8_t *src, uint32_t w, uint32_t 
         auto b = (sx&1)?
             src[sx>>1]&0xF:
             src[sx>>1]>>4;
-        if(b) *line = b;
+        *line = b;
         line++;
         sx++;
     }


### PR DESCRIPTION
The solid copy wasn't solid ;-) but supported transparent pixels. Changed that to be just solid.