### PR TITLE
Fixed call to lcdRefreshMode1 in PokittoDisplay.cpp

### DIFF
--- a/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
+++ b/Pokitto/POKITTO_CORE/PokittoDisplay.cpp
@@ -1115,7 +1115,7 @@ void Display::lcdRefresh(const unsigned char* scr, bool useDirectDrawMode) {
 #endif
 
 #if PROJ_SCREENMODE == MODE_HI_4COLOR
-    lcdRefreshMode1(scr, paletteptr);
+    lcdRefreshMode1(scr, 0, 0, 220, 176, paletteptr);
 #endif
 
 #if PROJ_SCREENMODE == MODE13

--- a/Pokitto/POKITTO_HW/HWLCD.cpp
+++ b/Pokitto/POKITTO_HW/HWLCD.cpp
@@ -480,7 +480,7 @@ void Pokitto::lcdRectangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint1
  * @param updRectH The update rect.
  * @param paletteptr The screen palette.
  */
-void Pokitto::lcdRefreshMode1(const uint8_t *scrbuf, const uint16_t *paletteptr) {
+void Pokitto::lcdRefreshMode1(const uint8_t *scrbuf, uint8_t updRectX, uint8_t updRectY, uint8_t updRectW, uint8_t updRectH, const uint16_t *paletteptr) {
     volatile uint32_t palette[32];
     for( uint32_t i=0; i<16; ++i ){
         palette[(i<<1)+1] = static_cast<uint32_t>(paletteptr[i&3 ]) << 3;

--- a/Pokitto/POKITTO_HW/HWLCD.h
+++ b/Pokitto/POKITTO_HW/HWLCD.h
@@ -80,7 +80,7 @@ extern void lcdInit();
 extern void lcdSleep();
 extern void lcdWakeUp();
 extern void lcdRefresh(uint8_t *, uint16_t*);
-extern void lcdRefreshMode1(const uint8_t* scrbuf, const uint16_t* paletteptr);
+extern void lcdRefreshMode1(const uint8_t* scrbuf, uint8_t updRectX, uint8_t updRectY, uint8_t updRectW, uint8_t updRectH, const uint16_t* paletteptr);
 extern void lcdRefreshMode2(const uint8_t *, const uint16_t*);
 extern void lcdRefreshMode13(const uint8_t *, const uint16_t*, uint8_t);
 extern void lcdRefreshMixMode(const uint8_t *, const uint16_t*, const uint8_t*);


### PR DESCRIPTION
The definition of lcdRefreshMode1 in HWLCD and SIMLCD didn't match and the PokittoDisplay.cpp called the HW one, but this then broke when building for SIM. Updated the HWLCD function to match the parameters used by SIMLCD and updated PokittoDisplay.cpp to specify the update area.

Not sure if the update area is actually used but this is the simplest solution for now.