### PR TITLE
Update PokittoHWSink.hpp to allow reuse of the timer.

### DIFF
--- a/Pokitto/POKITTO_LIBS/LibAudio/PokittoHWSink.hpp
+++ b/Pokitto/POKITTO_LIBS/LibAudio/PokittoHWSink.hpp
@@ -128,10 +128,12 @@ namespace Audio {
 
     public:
         void init(){
-            NVIC_SetVector((IRQn_Type)TIMER_32_0_IRQn, (uint32_t)IRQ);
             if(this->wasInit)
                 return;
             this->wasInit = true;
+
+			// only init the timer if not setup already
+            NVIC_SetVector((IRQn_Type)TIMER_32_0_IRQn, (uint32_t)IRQ);
 
             // enable amp
             LPC_GPIO_PORT->SET[1] = (1 << 17);


### PR DESCRIPTION
Moved if(this->wasInit) up and only init the timer if not already running. This fixes issues with reusing the timer for other thing.